### PR TITLE
Fix scrape job schedule syntax

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -5,8 +5,8 @@ on:
   # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
   schedule:
     # https://crontab.guru/
-    # '0/n' = 'every n minutes'
-    - cron: "0/10 * * * *"
+    # '*/n' = 'every n minutes'
+    - cron: "*/10 * * * *"
 
 jobs:
   scrape:


### PR DESCRIPTION
**Description**
Corrige la programmation de la GitHub Action.

**Motivation**
Suite à #1 la GitHub Action devait tourner toutes les 10min mais aucun run ne s'est encore lancé.

**Autres détails**
`0/10` ne correspondait pas à ce à quoi je m'attendais, `*/10` semble être correct

Cf [crontab.guru](https://crontab.guru/#*/10_*_*_*_*):

> At every 10th minute.