### PR TITLE
Doctolib: get the slot on the next week.

### DIFF
--- a/scraper/prototype.py
+++ b/scraper/prototype.py
@@ -151,7 +151,7 @@ def fetch_doctolib_slots(rdv_site_web, start_date):
         if len(slot['slots']) > 0:
             return slot['slots'][0]['start_date']
 
-    return None
+    return slots.get('next_slot')
 
 
 def centre_iterator():


### PR DESCRIPTION
Sur le site web, lorsqu'il n'y a aucun créneaux disponibles pour la semaine sélectionnée, la date du prochain créneau disponible est affichée (la semaine suivante ou plus tard).

Cette PR récupère cette information (uniquement la date sans l'heure comme sur le site web).