### PR TITLE
departements.py: Replace RuntimeError by ValueError

### DIFF
--- a/scraper/departements.py
+++ b/scraper/departements.py
@@ -73,6 +73,6 @@ def _clean_insee_code(insee_code: str) -> str:
         insee_code = f"0{insee_code}"
 
     if len(insee_code) != 5:
-        raise RuntimeError(f'Code INSEE non-valide : {insee_code}')
+        raise ValueError(f'Code INSEE non-valide : {insee_code}')
 
     return insee_code

--- a/scraper/prototype.py
+++ b/scraper/prototype.py
@@ -34,7 +34,11 @@ def cherche_prochain_rdv_dans_centre(centre):
         next_slot = None
         plateforme = None
 
-    departement = to_departement_number(insee_code=centre['com_insee'])
+    try:
+        departement = to_departement_number(insee_code=centre['com_insee'])
+    except ValueError:
+        print(f"erreur lors du traitement de la ligne avec le gid {centre['gid']}, com_insee={centre['com_insee']}")
+        departement = ''
 
     print(plateforme, next_slot, departement)
 


### PR DESCRIPTION
Dans la branche `main`, un département non renseigné arrête entièrement le script (La `RuntimeError` est propagée jusqu'à la fonction `main`).
Exemple: le gid 2269 n'a pas de département, il est indiqué comme "en cours de déclaration" dans le nom.

Cette PR léve une `ValueError` qui est interceptée dans `prototype.py`