### PR TITLE
More readable output

### DIFF
--- a/scraper/prototype.py
+++ b/scraper/prototype.py
@@ -36,7 +36,7 @@ def cherche_prochain_rdv_dans_centre(centre):
 
     departement = to_departement_number(insee_code=centre['com_insee'])
 
-    print(plateforme, next_slot, departement)
+    print(f'{centre["gid"]:>8} {plateforme:16} {next_slot or ""!s:32} {departement:6}')
 
     return {
         'departement': departement,


### PR DESCRIPTION
Exemple:
```
     727 Doctolib         2021-04-22                       49    
    1653 Autre                                             94    
    1645 Autre                                             28    
     388 Doctolib                                          34    
    1680 Doctolib                                          78    
    1709 Doctolib                                          62    
    2237 Autre                                             90    
    1718 Doctolib                                          89    
     697 Doctolib         2021-04-07T16:20:00.000+02:00    73    
    1549 Autre                                             75    
    1186 Doctolib         2021-04-06T11:30:00.000+02:00    81    
    1723 Doctolib                                          60    
     509 Keldoc                                            14    
    1646 Autre                                             28    
    1681 Autre                                             95    
    1053 Doctolib         2021-04-21                       48    
    2307 Doctolib         2021-04-16                       71    
    1739 Keldoc                                            974   
    1719 Doctolib                                          33    
     700 Doctolib         2021-04-13                       73    
     215 Doctolib         2021-04-18                       30    
    1733 Doctolib                                          64    
```

La première colonne est le GID.