### PR TITLE
Add tests to Doctolib implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+httpx==0.17.1
 requests[socks]==2.25.1
 pytest==6.2.2

--- a/scraper/doctolib.py
+++ b/scraper/doctolib.py
@@ -1,83 +1,148 @@
 import os
-import io
 import re
 import requests
+import httpx
+from typing import Optional, Tuple
 
-
-session = requests.Session()
-if os.getenv('WITH_TOR', 'no') == 'yes':
-    session.proxies = {'http': 'socks5://127.0.0.1:9050', 'https': 'socks5://127.0.0.1:9050'}
-
-DOCTOLIB_HEADERS = {
-    'X-Covid-Tracker-Key': os.environ.get('DOCTOLIB_API_KEY', None)
+DEFAULT_HEADERS = {
+    'X-Covid-Tracker-Key': os.environ.get('DOCTOLIB_API_KEY', ''),
 }
+
+DEFAULT_CLIENT: httpx.Client
+
+if os.getenv('WITH_TOR', 'no') == 'yes':
+    DEFAULT_CLIENT = requests.Session(  # type: ignore
+        proxies={
+            'http': 'socks5://127.0.0.1:9050',
+            'https': 'socks5://127.0.0.1:9050',
+        },
+    )
+else:
+    DEFAULT_CLIENT = httpx.Client()
 
 
 def fetch_slots(rdv_site_web, start_date):
-    centre = re.search(r'\/([^`\/]+)\?', rdv_site_web)
-    if centre:
-        # nouvelle URL https://partners.doctolib.fr/...
-        centre = centre.group(1)
-    else:
-        # ancienne URL https://www.doctolib.fr/....
-        # centre est en minuscule
-        centre = rdv_site_web.split('/')[-1].lower()
-        if centre == '':
+    # Fonction principale avec le comportement "de prod".
+    doctolib = DoctolibSlots(client=DEFAULT_CLIENT)
+    return doctolib.fetch(rdv_site_web, start_date)
+
+
+class DoctolibSlots:
+    # Permet de passer un faux client HTTP,
+    # pour éviter de vraiment appeler Doctolib lors des tests.
+
+    def __init__(self, client: httpx.Client = None) -> None:
+        self._client = DEFAULT_CLIENT if client is None else client
+
+    def fetch(self, rdv_site_web: str, start_date: str) -> Optional[str]:
+        centre = _parse_centre(rdv_site_web)
+
+        centre_api_url = f'https://partners.doctolib.fr/booking/{centre}.json'
+        response = self._client.get(centre_api_url, headers=DEFAULT_HEADERS)
+        response.raise_for_status()
+        data = response.json()
+
+        # visit_motive_categories
+        # example: https://partners.doctolib.fr/hopital-public/tarbes/centre-de-vaccination-tarbes-ayguerote?speciality_id=5494&enable_cookies_consent=1
+        visit_category_id = _find_visit_motive_category_id(data)
+        if visit_category_id is None:
             return None
 
-    centre_api_url = f'https://partners.doctolib.fr/booking/{centre}.json'
-    response = session.get(centre_api_url, headers=DOCTOLIB_HEADERS)
-    response.raise_for_status()
-    data = response.json()
+        # visit_motive_id
+        visit_motive_id = _find_visit_motive_id(data, visit_category_id)
+        if visit_motive_id is None:
+            return None
 
-    # visit_motive_categories
-    # example: https://partners.doctolib.fr/hopital-public/tarbes/centre-de-vaccination-tarbes-ayguerote?speciality_id=5494&enable_cookies_consent=1
-    visit_category = None
+        # practice_ids / agenda_ids
+        agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id)
+        if not agenda_ids or not practice_ids:
+            return None
+
+        # temporary_booking_disabled ??
+
+        slots_api_url = 'https://partners.doctolib.fr/availabilities.json'
+        params = {
+            "start_date": start_date,
+            "visit_motive_ids": visit_motive_id,
+            "agenda_ids": "-".join(agenda_ids),
+            "practice_ids": "-".join(practice_ids),
+            "insurance_sector": "public",
+            "destroy_temporary": True,
+            "limit": 7,
+        }
+
+        response = self._client.get(slots_api_url, params=params, headers=DEFAULT_HEADERS)
+        response.raise_for_status()
+
+        slots = response.json()
+        for slot in slots['availabilities']:
+            if len(slot['slots']) > 0:
+                return slot['slots'][0]['start_date']
+
+        return slots.get('next_slot')
+
+
+def _parse_centre(rdv_site_web: str) -> Optional[str]:
+    """
+    Etant donné l'URL de la page web correspondant au centre de vaccination,
+    renvoie le nom du centre de vaccination, en lowercase.
+    """
+    match = re.search(r'\/([^`\/]+)\?', rdv_site_web)
+    if match:
+        # nouvelle URL https://partners.doctolib.fr/...
+        return match.group(1)
+
+    # ancienne URL https://www.doctolib.fr/....
+    # centre doit être en minuscule
+    centre = rdv_site_web.split('/')[-1].lower()
+    if centre == '':
+        return None
+    return centre
+
+
+def _find_visit_motive_category_id(data: dict) -> Optional[str]:
+    """
+    Etant donnée une réponse à /booking/<centre>.json, renvoie le cas échéant
+    l'ID de la catégorie de motif correspondant à 'Non professionnels de santé'
+    (qui correspond à la population civile).
+    """
     for category in data.get('data', {}).get('visit_motive_categories', []):
         if category['name'] == 'Non professionnels de santé':
-            visit_category = category['id']
-            break
+            return category['id']
+    return None
 
-    # visit_motive_id
-    visit_motive_id = None
+
+def _find_visit_motive_id(data: dict, visit_motive_category_id: str) -> Optional[str]:
+    """
+    Etant donnée une réponse à /booking/<centre>.json, renvoie le cas échéant
+    l'ID du 1er motif de visite disponible correspondant à une 1ère dose pour
+    la catégorie de motif attendue.
+    """
     for visit_motive in data.get('data', {}).get('visit_motives', []):
-        if visit_motive['name'].startswith('1ère injection vaccin COVID-19') \
-           and visit_motive.get('visit_motive_category_id') == visit_category:
-            visit_motive_id = visit_motive['id']
-            break
+        # On ne gère que les 1ère doses (le RDV pour la 2e dose est en général donné
+        # après la 1ère dose, donc les gens n'ont pas besoin d'aide pour l'obtenir).
+        if not visit_motive['name'].startswith('1ère injection vaccin COVID-19'):
+            continue
+        if visit_motive.get('visit_motive_category_id') == visit_motive_category_id:
+            return visit_motive['id']
+    return None
 
-    if visit_motive_id is None:
-        return None
 
-    # practice_ids / agenda_ids
+def _find_agenda_and_practice_ids(data: dict, visit_motive_id: str) -> Tuple[list, list]:
+    """
+    Etant donné une réponse à /booking/<centre>.json, renvoie tous les
+    "agendas" et "pratiques" (jargon Doctolib) qui correspondent au motif de visite.
+    On a besoin de ces valeurs pour récupérer les disponibilités.
+    """
     agenda_ids = []
     practice_ids = []
     for agenda in data['data']['agendas']:
         if agenda['booking_disabled']:
             continue
         agenda_id = str(agenda['id'])
-        for pratice_id, visit_motive_list in agenda['visit_motive_ids_by_practice_id'].items():
-            if visit_motive_id in visit_motive_list:
+        for pratice_id, visit_motive_ids in agenda['visit_motive_ids_by_practice_id'].items():
+            if visit_motive_id in visit_motive_ids:
                 practice_ids.append(str(pratice_id))
                 if agenda_id not in agenda_ids:
                     agenda_ids.append(agenda_id)
-
-    if not agenda_ids or not practice_ids:
-        return None
-
-
-    # temporary_booking_disabled ??
-    agenda_ids = '-'.join(agenda_ids)
-    practice_ids = '-'.join(practice_ids)
-
-    slots_api_url = f'https://partners.doctolib.fr/availabilities.json?start_date={start_date}&visit_motive_ids={visit_motive_id}&agenda_ids={agenda_ids}&insurance_sector=public&practice_ids={practice_ids}&destroy_temporary=true&limit=7'
-
-    response = session.get(slots_api_url, headers=DOCTOLIB_HEADERS)
-    response.raise_for_status()
-
-    slots = response.json()
-    for slot in slots['availabilities']:
-        if len(slot['slots']) > 0:
-            return slot['slots'][0]['start_date']
-
-    return slots.get('next_slot')
+    return agenda_ids, practice_ids

--- a/scraper/doctolib.py
+++ b/scraper/doctolib.py
@@ -61,7 +61,9 @@ class DoctolibSlots:
 
         # temporary_booking_disabled ??
 
-        slots_api_url = f'https://partners.doctolib.fr/availabilities.json?start_date={start_date}&visit_motive_ids={visit_motive_id}&agenda_ids={agenda_ids}&insurance_sector=public&practice_ids={practice_ids}&destroy_temporary=true&limit=7'
+        agenda_ids_q = "-".join(agenda_ids)
+        practice_ids_q = "-".join(practice_ids)
+        slots_api_url = f'https://partners.doctolib.fr/availabilities.json?start_date={start_date}&visit_motive_ids={visit_motive_id}&agenda_ids={agenda_ids_q}&insurance_sector=public&practice_ids={practice_ids_q}&destroy_temporary=true&limit=7'
 
         response = self._client.get(slots_api_url, headers=DOCTOLIB_HEADERS)
         response.raise_for_status()

--- a/tests/fixtures/doctolib/basic-availabilities.json
+++ b/tests/fixtures/doctolib/basic-availabilities.json
@@ -1,0 +1,11 @@
+{
+  "availabilities": [
+    {
+      "slots": [
+        {
+          "start_date": "2021-04-10"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/doctolib/basic-booking.json
+++ b/tests/fixtures/doctolib/basic-booking.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "visit_motive_categories": [
+      {
+        "id": 1,
+        "name": "Non professionnels de santé"
+      }
+    ],
+    "visit_motives": [
+      {
+        "id": 2,
+        "visit_motive_category_id": 1,
+        "name": "1ère injection vaccin COVID-19 (Moderna)"
+      }
+    ],
+    "agendas": [
+      {
+        "id": 3,
+        "visit_motive_ids_by_practice_id": {
+          "4": [2]
+        },
+        "booking_disabled": false
+      }
+    ]
+  }
+}

--- a/tests/fixtures/doctolib/next-slot-availabilities.json
+++ b/tests/fixtures/doctolib/next-slot-availabilities.json
@@ -1,0 +1,8 @@
+{
+  "availabilities": [
+    {
+      "slots": []
+    }
+  ],
+  "next_slot": "2021-04-10"
+}

--- a/tests/fixtures/doctolib/next-slot-booking.json
+++ b/tests/fixtures/doctolib/next-slot-booking.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "visit_motive_categories": [
+      {
+        "id": 1,
+        "name": "Non professionnels de santé"
+      }
+    ],
+    "visit_motives": [
+      {
+        "id": 2,
+        "visit_motive_category_id": 1,
+        "name": "1ère injection vaccin COVID-19 (Moderna)"
+      }
+    ],
+    "agendas": [
+      {
+        "id": 3,
+        "visit_motive_ids_by_practice_id": {
+          "4": [2]
+        },
+        "booking_disabled": false
+      }
+    ]
+  }
+}

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -1,0 +1,196 @@
+import json
+from pathlib import Path
+
+import httpx
+from scraper.doctolib import (
+    DoctolibSlots,
+    _find_agenda_and_practice_ids,
+    _find_visit_motive_category_id,
+    _find_visit_motive_id,
+    _parse_centre,
+)
+
+
+# -- Tests de l'API (offline) --
+
+
+def test_doctolib():
+    # Cas de base.
+
+    start_date = "2021-04-03"
+    rdv_site_web = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville1/centre1?pid=practice-165752&enable_cookies_consent=1"  # noqa
+
+    def app(request: httpx.Request) -> httpx.Response:
+        assert "X-Covid-Tracker-Key" in request.headers
+
+        if request.url.path == "/booking/centre1.json":
+            path = Path("tests", "fixtures", "doctolib", "basic-booking.json")
+            return httpx.Response(200, json=json.loads(path.read_text()))
+
+        assert request.url.path == "/availabilities.json"
+        params = dict(httpx.QueryParams(request.url.query))
+        assert params == {
+            "start_date": start_date,
+            "visit_motive_ids": "2",
+            "agenda_ids": "3",
+            "insurance_sector": "public",
+            "practice_ids": "4",
+            "destroy_temporary": "true",
+            "limit": "7",
+        }
+        path = Path("tests", "fixtures", "doctolib", "basic-availabilities.json")
+        return httpx.Response(200, json=json.loads(path.read_text()))
+
+    client = httpx.Client(transport=httpx.MockTransport(app))
+    slots = DoctolibSlots(client=client)
+
+    next_date = slots.fetch(rdv_site_web, start_date)
+    assert next_date == "2021-04-10"
+
+
+def test_doctolib_next_slot():
+    # Cas de repli : c'est surprenant, mais parfois la liste des dispos
+    # est vide, mais il y a un champ 'next_slot' qui contient la date de
+    # la prochaine visite, que l'on utilise dans ce cas.
+
+    start_date = "2021-04-03"
+    rdv_site_web = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville1/centre1?pid=practice-165752&enable_cookies_consent=1"  # noqa
+
+    def app(request: httpx.Request) -> httpx.Response:
+        assert "X-Covid-Tracker-Key" in request.headers
+
+        if request.url.path == "/booking/centre1.json":
+            path = Path("tests", "fixtures", "doctolib", "next-slot-booking.json")
+            return httpx.Response(200, json=json.loads(path.read_text()))
+
+        assert request.url.path == "/availabilities.json"
+        path = Path("tests", "fixtures", "doctolib", "next-slot-availabilities.json")
+        return httpx.Response(200, json=json.loads(path.read_text()))
+
+    client = httpx.Client(transport=httpx.MockTransport(app))
+    slots = DoctolibSlots(client=client)
+
+    next_date = slots.fetch(rdv_site_web, start_date)
+    assert next_date == "2021-04-10"
+
+
+# -- Tests unitaires --
+
+
+def test_parse_centre():
+    # Nouvelle URL
+    url = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville1/centre1?pid=practice-165752&enable_cookies_consent=1"  # noqa
+    assert _parse_centre(url) == "centre1"
+
+    # Ancienne URL
+    url = "https://www.doctolib.fr/centre-de-vaccinations-internationales/ville2/Centre2"  # noqa
+    _parse_centre(url) == "centre2"
+
+    # URL invalide
+    url = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville2/"
+    assert _parse_centre(url) is None
+
+
+def test_find_visit_motive_category_id():
+    data = {
+        "data": {
+            "visit_motive_categories": [
+                {"id": 41, "name": "Professionnels de santé"},
+                {"id": 42, "name": "Non professionnels de santé"},
+            ]
+        }
+    }
+    assert _find_visit_motive_category_id(data) == 42
+
+
+def test_find_visit_motive_id():
+    # Un seul motif dispo
+    data = {
+        "data": {
+            "visit_motives": [
+                {
+                    "id": 1,
+                    "visit_motive_category_id": 42,
+                    "name": "1ère injection vaccin COVID-19 (Moderna)",
+                }
+            ]
+        }
+    }
+    assert _find_visit_motive_id(data, visit_motive_category_id=42) == 1
+
+    # Plusieurs motifs dispo => on choisit le 1er dans la liste.
+    data = {
+        "data": {
+            "visit_motives": [
+                {
+                    "id": 1,
+                    "visit_motive_category_id": 42,
+                    "name": "1ère injection vaccin COVID-19 (Pfizer/BioNTech)",
+                },
+                {"id": 2, "name": "1ère injection vaccin COVID-19 (Moderna)"},
+            ]
+        }
+    }
+    assert _find_visit_motive_id(data, visit_motive_category_id=42) == 1
+
+    # Mix avec un motif autre
+    data = {
+        "data": {
+            "visit_motives": [
+                {"id": 1, "visit_motive_category_id": 42, "name": "Autre motif"},
+                {
+                    "id": 2,
+                    "visit_motive_category_id": 42,
+                    "name": "1ère injection vaccin COVID-19 (Moderna)",
+                },
+            ]
+        }
+    }
+    assert _find_visit_motive_id(data, visit_motive_category_id=42) == 2
+
+    # Mix avec une catégorie autre
+    data = {
+        "data": {
+            "visit_motives": [
+                {
+                    "id": 1,
+                    "visit_motive_category_id": 41,
+                    "name": "1ère injection vaccin COVID-19 (Moderna)",
+                },
+                {
+                    "id": 2,
+                    "visit_motive_category_id": 42,
+                    "name": "1ère injection vaccin COVID-19 (Moderna)",
+                },
+            ]
+        }
+    }
+    assert _find_visit_motive_id(data, visit_motive_category_id=42) == 2
+
+
+def test_find_agenda_and_practice_ids():
+    data = {
+        "data": {
+            "agendas": [
+                {
+                    "id": 10,
+                    "booking_disabled": False,
+                    "visit_motive_ids_by_practice_id": {
+                        "20": [1, 2],
+                        "21": [1],
+                        "22": [2],  # => Pas inclus
+                    },
+                },
+                {
+                    "id": 11,
+                    "booking_disabled": True,  # => Pas inclus
+                    "visit_motive_ids_by_practice_id": {
+                        "23": [1, 2],
+                    },
+                },
+            ],
+        },
+    }
+    agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=1)
+    assert agenda_ids == ["10"]
+    assert practice_ids == ["20", "21"]


### PR DESCRIPTION
Ajout de tests de l'intégration Doctolib :

* Refacto de l'implémentation pour qu'on puisse "swap" les appels à l'API réelle par autre chose. Je suis parti sur HTTPX et ses [`MockTransport`](https://www.python-httpx.org/advanced/#mock-transports) (d'expérience, avec Requests ça aurait été galère à faire de façon aussi élégante). J'ai gardé Requests pour le debugging Tor (le `.get()` de HTTPX et Requests sont compatibles pour notre use case), en follow-up on pourrait voir si `httpx-socks` fait le job.
* La refacto permet d'ajouter toute une batterie de tests : tests d'API avec un "mock transport" qui renvoie des réponses JSON prémâchées, et des TU pour la logique de parsing des réponses.