### PR TITLE
Add publish script

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -26,9 +26,8 @@ jobs:
       - name: "Install"
         run: scripts/install
       - name: "Scraping..."
-        run: venv/bin/python3 -m scraper.prototype
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Automatic Update
-          branch: data-auto
-          push_options: '--force origin data-auto'
+        run: scripts/scrape
+      - name: "Publish"
+        run: scripts/publish
+        env:
+          TARGET_BRANCH: data-auto

--- a/scrape.py
+++ b/scrape.py
@@ -1,1 +1,3 @@
-print("TODO")
+from scraper import main
+
+main()

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+TARGET_BRANCH="${TARGET_BRANCH:-data-auto}"
+
+set -x
+
+# Ensure the test suite passes before publishing.
+scripts/test
+
+# Deal with detached head state that GitHub Actions puts us in
+git checkout main
+set +e; git branch -D $TARGET_BRANCH; set -e  # Branch may not exist yet; don't fail.
+git checkout -b $TARGET_BRANCH
+
+# Create a commit with the date attached
+datetime=`date "+%Y-%m-%d"`
+git add data/output/
+git commit -m "Automated update on $datetime"
+
+# Push the commit
+git push --force --set-upstream origin $TARGET_BRANCH


### PR DESCRIPTION
On termine la pipeline de mise en prod :

* Branche directement `scrape.py` sur le proto (`scripts/scrape` inchangé)
* Ajoute `scripts/publish` qui 1) crée un commit avec les changements dans `data/output/`, 2) push ce commit vers une branche cible
* Branche `scripts/publish` dans la GHA `scrape.yml`

Vous pouvez tester en local en ajoutant des trucs dans `data/output/` puis en exécutant le script avec une branche cible perso, par ex pour moi j'ai fait :

```bash
TARGET_BRANCH=data-auto-fm scripts/publish
```

Voici ce que ça donne : https://github.com/CovidTrackerFr/vitemadose/tree/data-auto-fm

Je garantis pas que ça fonctionnera dans la GHA (est-ce qu'on peut push sans avoir besoin de credentials supplémentaires ? etc), mais au moins on aura qqc qui fonctionne en local, et on pourra debug si besoin.