### PR TITLE
Action : run en permanence

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -20,10 +20,11 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v2"
+      with:
+          token: ${{ secrets.PAT_GRZ }}
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.8"
-          token: ${{ secrets.PAT_GRZ }}
       - name: "Install"
         run: scripts/install
       - name: "Scraping..."

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -20,8 +20,8 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v2"
-      with:
-          token: ${{ secrets.PAT_GRZ }}
+        with:
+            token: ${{ secrets.PAT_GRZ }}
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.8"

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -2,10 +2,10 @@
 name: Scrape
 
 on:
-  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
+  push:
+    branches:
+      - data-auto
   schedule:
-    # https://crontab.guru/
-    # '*/n' = 'every n minutes'
     - cron: "*/5 * * * *"
   # Allow running manually
   workflow_dispatch:
@@ -23,6 +23,7 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.8"
+          token: ${{ secrets.PAT_GRZ }}
       - name: "Install"
         run: scripts/install
       - name: "Scraping..."


### PR DESCRIPTION
Désormais l'action est run à chaque commit sur data-auto (donc c'est une sorte de boucle infinie…). 
Pour ça j'ai dû utiliser un PAT que j'ai généré (une Action ne peut pas être triggered par une action effectuant un commit avec le token de GitHub).