### PR TITLE
Add dateuitls and isoparse

### DIFF
--- a/scraper/maiia.py
+++ b/scraper/maiia.py
@@ -1,6 +1,7 @@
 import json
 import requests
 from datetime import datetime, timedelta
+from dateutil.parser import isoparse
 from bs4 import BeautifulSoup
 
 
@@ -49,8 +50,7 @@ def get_slots_from(rdv_form, rdv_url):
         return None
 
     if "firstPhysicalStartDateTime" in availability:
-        dt = datetime.strptime(availability['firstPhysicalStartDateTime'],
-                               '%Y-%m-%dT%H:%M:%S.%fZ')
+        dt = isoparse(availability['firstPhysicalStartDateTime'])
         dt = dt + timedelta(hours=2)
         dt = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         return dt
@@ -58,9 +58,7 @@ def get_slots_from(rdv_form, rdv_url):
     # Ne sachant pas si 'firstPhysicalStartDateTime' est un attribut par défault dans
     # la réponse, je préfère faire des tests sur l'existence des attributs
     if "closestPhysicalAvailability" in availability and "startDateTime" in availability:
-        dt = datetime.strptime(
-                availability['closestPhysicalAvailability']["startDateTime"],
-                '%Y-%m-%dT%H:%M:%S.%fZ')
+        dt = isoparse(availability['closestPhysicalAvailability']["startDateTime"])
         dt = dt + timedelta(hours=2)
         dt = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         return dt

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
         'httpx==0.17.1',
         'requests[socks]==2.25.1',
         'pytest==6.2.2',
-        'beautifulsoup4==4.9.3'
+        'beautifulsoup4==4.9.3',
+        'python-dateutil',
     ],
 )


### PR DESCRIPTION
Ajout du module `dateutils` afin de parser les dates renvoyées par maiia qui sont sous le format iso. C'est plus propre que le `datetime.strptime(availability['firstPhysicalStartDateTime'],
                               '%Y-%m-%dT%H:%M:%S.%fZ')` 
actuel.