### PR TITLE
Add test for practice_id filter

### DIFF
--- a/scraper/doctolib.py
+++ b/scraper/doctolib.py
@@ -42,7 +42,7 @@ class DoctolibSlots:
 
         # Doctolib fetches multiple vaccination centers sometimes
         # so if a practice id is present in query, only related agendas
-        # will be selected.
+        # should be selected.
         practice_id = _parse_practice_id(rdv_site_web)
 
         centre_api_url = f'https://partners.doctolib.fr/booking/{centre}.json'

--- a/scraper/doctolib.py
+++ b/scraper/doctolib.py
@@ -1,7 +1,6 @@
 import os
 import re
 from typing import Optional, Tuple
-from urllib.parse import urlsplit, parse_qs
 
 import httpx
 import requests


### PR DESCRIPTION
Ajoute un test pour le "hot fix" ajouté via ce commit 4cbbf2d5fb5f0206222596aeaea139999577233f

La fonctionnalité est refactorée pour l'occasion.

Remarques :

* J'ai retiré l'attribut `self.selected_practice_id`, en fait `DoctolibSlots()` est instancié à chaque appel à `fetch_slots()` donc pas lieu de stocker un attribut (et je pense pas qu'on veuille vraiment réutiliser ça de toute façon, vu que ça change à chaque URL).
* J'ai isolé le traitement dans une fonction à part, sans changer le traitement, ensuite ajouté mes tests, le cas "Broken 1" était HS, en utilisant HTTPX j'arrive à couvrir tous les tests avec un code + lisible.
* J'ai résolu un autre bug potentiel : l'argument `practice_id` était remplacé par la variable de boucle du même nom ! D'où `practice_id_filter`.