### PR TITLE
Add test coverage tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,8 @@ install: ## sets up package and its dependencies
 test: ## sets up package and its dependencies
 	scripts/test
 
+coverage: ## reports test coverage (automatically run by `test`)
+	scripts/coverage
+
 scrape: ## runs the full scraping experience
 	scripts/scrape

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+BIN="venv/bin/"
+
+set -x
+
+${BIN}coverage report --show-missing --skip-covered

--- a/scripts/test
+++ b/scripts/test
@@ -4,4 +4,6 @@ BIN="venv/bin/"
 
 set -x
 
-${BIN}pytest
+${BIN}coverage run -m pytest
+
+scripts/coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [tool:pytest]
 addopts = scraper/ tests/ --doctest-modules
+
+[coverage:run]
+omit = venv/*
+include = scraper/*, tests/*

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
         'httpx==0.17.1',
         'requests[socks]==2.25.1',
         'pytest==6.2.2',
-        'beautifulsoup4==4.9.3'
+        'beautifulsoup4==4.9.3',
+        'coverage==5.5',
     ],
 )


### PR DESCRIPTION
**Description**
Ajoute `coverage-py` au repo pour pouvoir afficher le coverage lors de l'exécution des tests

**Motivation**
Ça aidera pour tracker les "zones d'ombre" au niveau des tests. L'idée je pense serait d'avoir des tests fonctionnels qui couvrent déjà au moins ~80% du code (et affiner avec des TU ensuite, mais ça ça prendra + d'efforts, pas forcément rentable vu le rythme auquel on bouge).

**Notes**

```console
$ scripts/test
+ venv/bin/coverage run -m pytest
===================================================== test session starts =====================================================
platform darwin -- Python 3.9.0, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/florimond/Developer/covidtracker-projects/vitemadose, configfile: setup.cfg
collected 11 items                                                                                                            

scraper/departements.py ...                                                                                             [ 27%]
tests/test_doctolib.py ........                                                                                         [100%]

===================================================== 11 passed in 1.08s ======================================================
+ scripts/coverage
+ venv/bin/coverage report --show-missing --skip-covered
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
scraper/departements.py               19      2    89%   53, 76
scraper/doctolib.py                   90      9    90%   17-22, 29-30, 60, 67, 119, 161
scraper/keldoc/keldoc.py              25     14    44%   21-41
scraper/keldoc/keldoc_center.py       86     73    15%   16-23, 26-41, 44-56, 59-89, 92-120
scraper/keldoc/keldoc_filters.py      86     75    13%   23-30, 35-52, 56-75, 79-87, 91-120
scraper/maiia.py                      48     37    23%   15-27, 31-67, 71-79
scraper/prototype.py                  83     62    25%   20-31, 35-52, 62-66, 70-102, 106-113, 117-124, 128
----------------------------------------------------------------
TOTAL                                530    272    49%

5 files skipped due to complete coverage.
```