### PR TITLE
Add unit tests for export_data

### DIFF
--- a/scraper/prototype.py
+++ b/scraper/prototype.py
@@ -1,5 +1,5 @@
 import sys
-from datetime import datetime
+import datetime as dt
 from multiprocessing import Pool
 import json
 import os
@@ -32,7 +32,7 @@ def main():
 
 
 def cherche_prochain_rdv_dans_centre(centre):
-    start_date = datetime.now().isoformat()[:10]
+    start_date = dt.datetime.now().isoformat()[:10]
     try:
         plateforme, next_slot = fetch_centre_slots(centre['rdv_site_web'], start_date)
     except Exception as e:
@@ -66,13 +66,13 @@ def sort_center(center):
     return center['prochain_rdv']
 
 
-def export_data(centres_cherchés):
+def export_data(centres_cherchés, outpath_format='data/output/{}.json'):
     compte_centres = 0
     compte_centres_avec_dispo = 0
     par_departement = {
         code: {
             'version': 1,
-            'last_updated': datetime.now(tz=pytz.timezone('Europe/Paris')).isoformat(),
+            'last_updated': dt.datetime.now(tz=pytz.timezone('Europe/Paris')).isoformat(),
             'centres_disponibles': [],
             'centres_indisponibles': []
         }
@@ -95,8 +95,9 @@ def export_data(centres_cherchés):
     for code_departement, disponibilités in par_departement.items():
         if 'centres_disponibles' in disponibilités:
             disponibilités['centres_disponibles'] = sorted(disponibilités['centres_disponibles'], key=sort_center)
-        print(f'writing result to {code_departement}.json file')
-        with open(f'data/output/{code_departement}.json', "w") as outfile:
+        outpath = outpath_format.format(code_departement)
+        print(f'writing result to {outpath} file')
+        with open(outpath, "w") as outfile:
             outfile.write(json.dumps(disponibilités, indent=2))
 
     return compte_centres, compte_centres_avec_dispo

--- a/tests/test_prototype.py
+++ b/tests/test_prototype.py
@@ -1,10 +1,131 @@
-from scraper.prototype import fetch_centre_slots
+import datetime as dt
+import json
+from scraper.departements import import_departements
+from scraper.prototype import fetch_centre_slots, export_data
+
+from .utils import mock_datetime_now
+
+
+def test_export_data(tmp_path):
+    centres_cherchés = [
+        {
+            "departement": "01",
+            "nom": "Bugey Sud",
+            "url": "https://example.com/bugey-sud",
+            "plateforme": "Doctolib",
+            "prochain_rdv": "2021-04-10T00:00:00",
+        },
+        {
+            "departement": "59",
+            "nom": "CH Armentières",
+            "url": "https://example.com/ch-armentieres",
+            "plateforme": "Keldoc",
+            "prochain_rdv": "2021-04-10T00:00:00",
+        },
+        {
+            "departement": "59",
+            "nom": "Clinique du Cambresis",
+            "url": "https://example.com/clinique-du-cambresis",
+            "plateforme": "Maiia",
+            "prochain_rdv": None,
+        },
+        {
+            # Unknown departement (edge case) => should be skipped w/o failing
+            "departement": "1234",
+            "nom": "Hôpital magique",
+            "url": "https://example.com/hopital-magique",
+            "plateforme": "Doctolib",
+            "prochain_rdv": "2021-04-10T00:00:00",
+        },
+    ]
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    outpath_format = str(out_dir / "{}.json")
+
+    fake_now = dt.datetime(2021, 4, 4)
+    with mock_datetime_now(fake_now):
+        export_data(centres_cherchés, outpath_format=outpath_format)
+
+    for departement in import_departements():
+        if departement in ("01", "59"):  # These are non-empty.
+            continue
+        content = json.loads((out_dir / f"{departement}.json").read_text())
+        assert content == {
+            "version": 1,
+            "centres_disponibles": [],
+            "centres_indisponibles": [],
+            "last_updated": "2021-04-04T00:00:00",
+        }
+
+    # Departements 01 and 59 should contain expected data.
+
+    content = json.loads((out_dir / "01.json").read_text())
+    assert content == {
+        "version": 1,
+        "centres_disponibles": [
+            {
+                "departement": "01",
+                "nom": "Bugey Sud",
+                "url": "https://example.com/bugey-sud",
+                "plateforme": "Doctolib",
+                "prochain_rdv": "2021-04-10T00:00:00",
+            },
+        ],
+        "centres_indisponibles": [],
+        "last_updated": "2021-04-04T00:00:00",
+    }
+
+    content = json.loads((out_dir / "59.json").read_text())
+    assert content == {
+        "version": 1,
+        "centres_disponibles": [
+            {
+                "departement": "59",
+                "nom": "CH Armentières",
+                "url": "https://example.com/ch-armentieres",
+                "plateforme": "Keldoc",
+                "prochain_rdv": "2021-04-10T00:00:00",
+            },
+        ],
+        "centres_indisponibles": [
+            {
+                "departement": "59",
+                "nom": "Clinique du Cambresis",
+                "url": "https://example.com/clinique-du-cambresis",
+                "plateforme": "Maiia",
+                "prochain_rdv": None,
+            }
+        ],
+        "last_updated": "2021-04-04T00:00:00",
+    }
+
+
+def test_export_data_empty(tmp_path):
+    centres_cherchés = []
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    outpath_format = str(out_dir / "{}.json")
+
+    fake_now = dt.datetime(2021, 4, 4)
+    with mock_datetime_now(fake_now):
+        export_data(centres_cherchés, outpath_format=outpath_format)
+
+    content = json.loads((out_dir / "01.json").read_text())
+    assert content == {
+        "version": 1,
+        "centres_disponibles": [],
+        "centres_indisponibles": [],
+        "last_updated": "2021-04-04T00:00:00",
+    }
 
 
 def test_fetch_centre_slots():
     """
     We detect which implementation to use based on the visit URL.
     """
+
     def fake_doctolib_fetch_slots(rdv_site_web, start_date):
         return "2021-04-04"
 

--- a/tests/test_prototype.py
+++ b/tests/test_prototype.py
@@ -20,7 +20,7 @@ def test_export_data(tmp_path):
             "nom": "CH Armentières",
             "url": "https://example.com/ch-armentieres",
             "plateforme": "Keldoc",
-            "prochain_rdv": "2021-04-10T00:00:00",
+            "prochain_rdv": "2021-04-11:00:00",
         },
         {
             "departement": "59",
@@ -35,7 +35,7 @@ def test_export_data(tmp_path):
             "nom": "Hôpital magique",
             "url": "https://example.com/hopital-magique",
             "plateforme": "Doctolib",
-            "prochain_rdv": "2021-04-10T00:00:00",
+            "prochain_rdv": "2021-04-12:00:00",
         },
     ]
 
@@ -47,8 +47,9 @@ def test_export_data(tmp_path):
     with mock_datetime_now(fake_now):
         export_data(centres_cherchés, outpath_format=outpath_format)
 
+    # All departements for which we don't have data should be empty.
     for departement in import_departements():
-        if departement in ("01", "59"):  # These are non-empty.
+        if departement in ("01", "59"):
             continue
         content = json.loads((out_dir / f"{departement}.json").read_text())
         assert content == {
@@ -85,7 +86,7 @@ def test_export_data(tmp_path):
                 "nom": "CH Armentières",
                 "url": "https://example.com/ch-armentieres",
                 "plateforme": "Keldoc",
-                "prochain_rdv": "2021-04-10T00:00:00",
+                "prochain_rdv": "2021-04-11:00:00",
             },
         ],
         "centres_indisponibles": [
@@ -101,31 +102,10 @@ def test_export_data(tmp_path):
     }
 
 
-def test_export_data_empty(tmp_path):
-    centres_cherchés = []
-
-    out_dir = tmp_path / "out"
-    out_dir.mkdir()
-    outpath_format = str(out_dir / "{}.json")
-
-    fake_now = dt.datetime(2021, 4, 4)
-    with mock_datetime_now(fake_now):
-        export_data(centres_cherchés, outpath_format=outpath_format)
-
-    content = json.loads((out_dir / "01.json").read_text())
-    assert content == {
-        "version": 1,
-        "centres_disponibles": [],
-        "centres_indisponibles": [],
-        "last_updated": "2021-04-04T00:00:00",
-    }
-
-
 def test_fetch_centre_slots():
     """
     We detect which implementation to use based on the visit URL.
     """
-
     def fake_doctolib_fetch_slots(rdv_site_web, start_date):
         return "2021-04-04"
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,14 @@
+import datetime as dt
+from contextlib import contextmanager
+from unittest.mock import patch
+
+
+@contextmanager
+def mock_datetime_now(now):
+    class MockedDatetime(dt.datetime):
+        @classmethod
+        def now(cls, *args, **kwargs):
+            return now
+
+    with patch("datetime.datetime", MockedDatetime):
+        yield


### PR DESCRIPTION
Ajout d'un TU pour `export_data()`, qui est maintenant complètement couvert. :-)

Coverage mis à jour : `prototype.py` passe de 37% (#44) à 62% :tada:

```
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
scraper/departements.py               19      2    89%   53, 76
scraper/doctolib.py                   90      9    90%   17-22, 29-30, 60, 67, 119, 161
scraper/keldoc/keldoc.py              25     14    44%   21-41
scraper/keldoc/keldoc_center.py       86     73    15%   16-23, 26-41, 44-56, 59-89, 92-120
scraper/keldoc/keldoc_filters.py      86     75    13%   23-30, 35-52, 56-75, 79-87, 91-120
scraper/maiia.py                      48     37    23%   15-27, 31-67, 71-79
scraper/prototype.py                  88     33    62%   20-31, 35-52, 63, 65, 110, 134-141, 145
----------------------------------------------------------------
TOTAL                                587    243    59%

7 files skipped due to complete coverage.
```