### PR TITLE
prototype.py: trim whitespaces from center name

### DIFF
--- a/scraper/prototype.py
+++ b/scraper/prototype.py
@@ -80,6 +80,7 @@ def export_data(centres_cherchés, outpath_format='data/output/{}.json'):
     }
     
     for centre in centres_cherchés:
+        centre['nom'] = centre['nom'].strip()
         compte_centres += 1
         code_departement = centre['departement']
         if code_departement in par_departement:


### PR DESCRIPTION
Supprimer les espaces au début et de fin de chaîne sur les noms des caractères.

Exemple avec: 
```
"nom": "CH de Rodez H\u00f4pital Jacques Puel ",
```