### PR TITLE
Scrape one URL with more log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 .DEFAULT_GOAL := help
 
+URL =
+
 .PHONY: help test install
 help: ## provides cli help for this makefile (default) 📖
 	@grep -E '^[a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -15,8 +17,7 @@ coverage: ## reports test coverage (automatically run by `test`)
 	scripts/coverage
 
 scrape: ## runs the full scraping experience
-	scripts/scrape
+	scripts/scrape $(URL)
 
 stats: ## Run the statistiques scripts
 	venv/bin/python -m scraper.centres_stats
-RuntimeWarning: '' found in sys.modules after import of package '', but prior to execution of ''; this may result in unpredictable behaviour

--- a/scripts/scrape
+++ b/scripts/scrape
@@ -2,4 +2,4 @@
 
 BIN="venv/bin/"
 
-${BIN}python scrape.py
+${BIN}python scrape.py $@

--- a/utils/vmd_logger.py
+++ b/utils/vmd_logger.py
@@ -23,8 +23,12 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-def init_logger():
+def get_logger():
     # create logger
+    return logging.getLogger('scraper')
+
+
+def enable_logger_for_production():
     logger = logging.getLogger('scraper')
     logger.setLevel(logging.INFO)
 
@@ -32,4 +36,10 @@ def init_logger():
     ch.setLevel(logging.DEBUG)
     ch.setFormatter(CustomFormatter())
     logger.addHandler(ch)
-    return logger
+
+
+def enable_logger_for_debug():
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(CustomFormatter())
+    logging.basicConfig(level=logging.DEBUG, handlers=[ch])


### PR DESCRIPTION
Fix issue #39

Permet de lancer le script avec uniquement quelques URL: 
`script/scrape "<URL>" "<URL>" ....`

Ou

`make scrape URL=...` (une seule URL).

Dans ce cas le log des requests HTTP est affiché.