### PR TITLE
Added script to export availability stats by department

### DIFF
--- a/analytics/stats.py
+++ b/analytics/stats.py
@@ -1,40 +1,77 @@
 import json
+import os
+from datetime import datetime
+
 import pandas as pd
-from departements import to_departement_number, import_departements
-import matplotlib.pyplot as plt
-import numpy as np
 
-def my_fmt(x):
-    print(x)
-    return '{:.4f}%\n({:.0f})'.format(x, total*x/100)
+from scraper.departements import import_departements
+
+OUTPUT_DATA_DIRPATH = 'data/output/'
+OUTPUT_DATA_FILE = 'data/output/stats.json'
 
 
-
-centre_disponibles = pd.DataFrame()
-centres_indisponibles = pd.DataFrame()
-centres_all = pd.DataFrame()
-
-for code in import_departements():
-    data = open(f'data/output/{code}.json', 'r')
-    data_json = json.load(data)
-    centre_disponibles = centre_disponibles.append(
-        pd.DataFrame.from_dict(data_json["centres_disponibles"]))
-    centres_indisponibles = centres_indisponibles.append(
-        pd.DataFrame.from_dict(data_json["centres_indisponibles"]))
-    data.close()
-
-centres_all = pd.concat([centre_disponibles, centres_indisponibles])
+def get_all_data(codes=None):
+    """
+    Cette fonction peut prendre en parametre une liste de codes de departements (pour le debugging, essentiellement).
+    Par defaut, renvoie la donnee de tous les departements.
+    """
+    codes = codes or import_departements()
+    return pd.concat(get_formatted_departement_data(code) for code in codes)
 
 
+def get_formatted_departement_data(departement_code):
+    return _format_departement_data(_load_departement_data(departement_code))
 
 
-centres_all['prochain_rdv'] = centres_all['prochain_rdv'].apply(
-    lambda x: "Disponibles" if not pd.isnull(x) else "Indisponibles")
+def _load_departement_data(departement_code):
+    path = os.path.join(OUTPUT_DATA_DIRPATH, f'{departement_code}.json')
+    with open(path, 'r') as json_file:
+        return json.load(json_file)
 
-total = centres_all['prochain_rdv'].count()
-print(total)
 
-centres_all['prochain_rdv'].value_counts().plot(
-    kind='pie', autopct=my_fmt, title='Centre disponibles')
+def _format_departement_data(json_data):
+    available_centers = pd.json_normalize(json_data, 'centres_disponibles', ['last_updated'], record_prefix='')
+    available_centers['status'] = 'disponible'
+    unavailable_centers = pd.json_normalize(json_data, 'centres_indisponibles', ['last_updated'], record_prefix='')
+    unavailable_centers['status'] = 'indisponible'
+    return pd.concat([available_centers, unavailable_centers])
 
-plt.show()
+
+def _add_ratios(counts):
+    """
+    Ajoute quelques stats, telles que le nombre total de centres, ainsi que les proportions disponible/non-disponible.
+
+    Attention: cette fonction modifie son premier argument.
+    """
+    counts['total'] = counts.disponible + counts.indisponible
+    counts['ratio_disponible'] = counts.disponible / counts.total
+    counts['ratio_indisponible'] = counts.indisponible / counts.total
+    return counts
+
+
+def export_results_to_json(national_stats, stats_by_departement):
+    output_dict = {'computed_at': datetime.utcnow().isoformat(),
+                   'stat_by_departement': stats_by_departement.to_dict(orient='index'),
+                   'stat_nationale': national_stats.to_dict(orient='records')[0]}
+    with open(OUTPUT_DATA_FILE, 'w') as output_json_file:
+        json.dump(output_dict, output_json_file)
+
+
+def main():
+    all_centers = get_all_data()
+
+    # Statistiques au niveau national
+    national_stats = _add_ratios(all_centers.status.value_counts().to_frame().T)
+
+    # Statistiques par departement
+    stats_by_departement = (all_centers
+                            .groupby(['departement', 'status'])
+                            .size()
+                            .unstack(fill_value=0))
+    stats_by_departement = _add_ratios(stats_by_departement)
+
+    export_results_to_json(national_stats, stats_by_departement)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Ce script s'appuie sur le travail de @Maijin, et re-ecrit le script existant pour se concentrer sur la generation d'un JSON contenant quelques statistiques au niveau national et par departement.

Le JSON de sortie a le format suivant:

```
{'computed_at': '2021-04-05T19:12:48.289603',
 'stat_by_departement': 
    {'01': {'disponible': 6,
               'indisponible': 4,
               'ratio_disponible': 0.6,
               'ratio_indisponible': 0.4,
               'total': 10},
      '02': ... }
   'stat_nationale': 
        {'disponible': 226,
         'indisponible': 1889,
         'ratio_disponible': 0.106,
         'ratio_indisponible': 0.893,
         'total': 2115}
}
```

Le Colab d'exploration est disponible [ici](https://colab.research.google.com/drive/1zOZS7alKuFt9-XdgHjlA28gNytsO2lci?usp=sharing)

## TODO
- [ ] brancher le script (sur github actions ?) pour qu'il tourne regulierement et alimente le front