### PR TITLE
Using User-Agent due to Doctolib technical limitations

### DIFF
--- a/scraper/doctolib/doctolib.py
+++ b/scraper/doctolib/doctolib.py
@@ -11,7 +11,7 @@ from scraper.doctolib.doctolib_filters import is_appointment_relevant
 DOCTOLIB_SLOT_LIMIT = 50
 
 DOCTOLIB_HEADERS = {
-    'X-Covid-Tracker-Key': os.environ.get('DOCTOLIB_API_KEY', ''),
+    'User-Agent': os.environ.get('DOCTOLIB_API_KEY', ''),
 }
 
 DEFAULT_CLIENT: httpx.Client

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -23,7 +23,7 @@ def test_doctolib():
     rdv_site_web = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville1/centre1?pid=practice-165752&enable_cookies_consent=1"  # noqa
 
     def app(request: httpx.Request) -> httpx.Response:
-        assert "X-Covid-Tracker-Key" in request.headers
+        assert "User-Agent" in request.headers
 
         if request.url.path == "/booking/centre1.json":
             path = Path("tests", "fixtures", "doctolib", "basic-booking.json")
@@ -59,7 +59,7 @@ def test_doctolib_motive_categories():
     rdv_site_web = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville1/centre1?pid=practice-165752&enable_cookies_consent=1"  # noqa
 
     def app(request: httpx.Request) -> httpx.Response:
-        assert "X-Covid-Tracker-Key" in request.headers
+        assert "User-Agent" in request.headers
 
         if request.url.path == "/booking/centre1.json":
             path = Path("tests", "fixtures", "doctolib", "category-booking.json")
@@ -85,7 +85,7 @@ def test_doctolib_next_slot():
     rdv_site_web = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville1/centre1?pid=practice-165752&enable_cookies_consent=1"  # noqa
 
     def app(request: httpx.Request) -> httpx.Response:
-        assert "X-Covid-Tracker-Key" in request.headers
+        assert "User-Agent" in request.headers
 
         if request.url.path == "/booking/centre1.json":
             path = Path("tests", "fixtures", "doctolib", "next-slot-booking.json")


### PR DESCRIPTION
Doctolib préferait que l'on utilise l'User-Agent pour le moment, afin effectuer les requêtes chez eux, parce que le header en place causerait trop de problèmes pour la gestion de celui-ci.