### PR TITLE
Correction README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ La plupart des IDEs et éditeurs de code moderne proposent des outils permettant
 | <img src="https://www.keldoc.com/keldoc-logo.nolqip.e7abaad88d1642c9c1f2.png" width="100" /> | https://keldoc.com | <font style="color: green; font-size: 16px;">✓</font> |
 | <img src="https://www.rmingenierie.net/wp-content/uploads/2019/12/logo-Maiia-vert.png" width="100" /> | https://maiia.com | <font style="color: green; font-size: 16px;">✓</font> |
 | <img src="https://www.ordoclic.fr/wp-content/uploads/2019/03/Logo.png" width="100" /> | https://ordoclic.fr | <font style="color: green; font-size: 16px;">✓</font> |
-| <img src="https://www.mapharma.fr/media/logo/stores/2/logo_mapharma.png" width="100" /> | https://www.mapharma.fr/ | <font style="color: green; font-size: 16px;">✓</font> |
+| <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_mapharma.png" width="100" /> | https://www.mapharma.net/ | <font style="color: green; font-size: 16px;">✓</font> |
 | <img src="https://pharmagest.com/wp-content/uploads/PandaPatient2.jpg" width="100" /> | https://pharmagest.com/en/pandalab-agenda/ | <font style="color: orange; font-size: 16px;">En cours</font> |
 
 ## Utilisation

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ La plupart des IDEs et éditeurs de code moderne proposent des outils permettant
 
 | Plateforme        | Lien           | Supporté  |
 | ------------- |:-------------:| :-----:|
-| <img src="https://www.ch2p.bzh/wp-content/uploads/2020/02/Logo-doctolib-bleu-tr.png" width="100" /> | https://doctolib.fr/ | <font style="color: green; font-size: 16px;">✓</font> |
-| <img src="https://www.keldoc.com/keldoc-logo.nolqip.e7abaad88d1642c9c1f2.png" width="100" /> | https://keldoc.com | <font style="color: green; font-size: 16px;">✓</font> |
-| <img src="https://www.rmingenierie.net/wp-content/uploads/2019/12/logo-Maiia-vert.png" width="100" /> | https://maiia.com | <font style="color: green; font-size: 16px;">✓</font> |
-| <img src="https://www.ordoclic.fr/wp-content/uploads/2019/03/Logo.png" width="100" /> | https://ordoclic.fr | <font style="color: green; font-size: 16px;">✓</font> |
+| <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_doctolib.png" width="100" /> | https://doctolib.fr/ | <font style="color: green; font-size: 16px;">✓</font> |
+| <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_keldoc.png" width="100" /> | https://keldoc.com | <font style="color: green; font-size: 16px;">✓</font> |
+| <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_maiia.png" width="100" /> | https://maiia.com | <font style="color: green; font-size: 16px;">✓</font> |
+| <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_ordoclic.png" width="100" /> | https://ordoclic.fr | <font style="color: green; font-size: 16px;">✓</font> |
 | <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_mapharma.png" width="100" /> | https://www.mapharma.net/ | <font style="color: green; font-size: 16px;">✓</font> |
-| <img src="https://pharmagest.com/wp-content/uploads/PandaPatient2.jpg" width="100" /> | https://pharmagest.com/en/pandalab-agenda/ | <font style="color: orange; font-size: 16px;">En cours</font> |
+| <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_pandalab.png" width="100" /> | https://pharmagest.com/en/pandalab-agenda/ | <font style="color: orange; font-size: 16px;">En cours</font> |
 
 ## Utilisation
 


### PR DESCRIPTION
- Remplacement de mapharma.fr par mapharma.net (@Noezor a le revert un peu trop large :sweat_smile:)
- Utilisation de nos assets pour les images plutôt que de récupérer des liens "aléatoires"