### PR TITLE
Fixed Keldoc issues with several agendas (timeout)

### DIFF
--- a/scraper/keldoc/keldoc.py
+++ b/scraper/keldoc/keldoc.py
@@ -6,10 +6,10 @@ from scraper.keldoc.keldoc_center import KeldocCenter
 from scraper.keldoc.keldoc_filters import filter_vaccine_specialties, filter_vaccine_motives
 from scraper.pattern.scraper_request import ScraperRequest
 
-timeout = httpx.Timeout(15.0, connect=15.0)
+timeout = httpx.Timeout(60.0, connect=60.0)
 session = httpx.Client(timeout=timeout)
 
-KELDOC_SLOT_LIMIT = 50
+KELDOC_SLOT_LIMIT = 21
 
 
 def fetch_slots(request: ScraperRequest):

--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -7,7 +7,7 @@ from scraper.keldoc.keldoc_filters import parse_keldoc_availability
 from scraper.keldoc.keldoc_routes import API_KELDOC_CALENDAR, API_KELDOC_CENTER, API_KELDOC_CABINETS
 from scraper.pattern.scraper_request import ScraperRequest
 
-timeout = httpx.Timeout(10.0, connect=10.0)
+timeout = httpx.Timeout(20.0, connect=20.0)
 DEFAULT_CLIENT = httpx.Client(timeout=timeout)
 
 

--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -7,7 +7,7 @@ from scraper.keldoc.keldoc_filters import parse_keldoc_availability
 from scraper.keldoc.keldoc_routes import API_KELDOC_CALENDAR, API_KELDOC_CENTER, API_KELDOC_CABINETS
 from scraper.pattern.scraper_request import ScraperRequest
 
-timeout = httpx.Timeout(20.0, connect=20.0)
+timeout = httpx.Timeout(60.0, connect=60.0)
 DEFAULT_CLIENT = httpx.Client(timeout=timeout)
 
 


### PR DESCRIPTION
Dû au problème de certains centres qui n'ont pas de rendez-vous trouvés (cf. issue https://github.com/CovidTrackerFr/vitemadose/issues/161), j'ai fait une petite investigation sur le sujet, comme ça me paraissait étonnant qu'il y ait un souci avec Keldoc.

Après petite vérification, c'est bien la requête vers Keldoc qui timeout, parce que le centre de Toulouse (en l'occurrence c'est celui que j'ai testé) avait de nombreux agendas internes dans les données du centre, je présume que la requête est trop lourde à supporter pour Keldoc de vérifier pour 50 jours (aie, pas de caching de leur côté).

Du coup j'ai décidé d'augmenter le timeout et de baisser le nombre de jours à 21 (soit 3 semaines) afin d'être moins méchant vis-à-vis de leur API, et ça a l'air de faire baisser le temps de la requête.