### PR TITLE
Added MaPharma User Agent

### DIFF
--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -1,3 +1,5 @@
+import os
+
 import httpx
 import json
 import logging
@@ -9,8 +11,12 @@ from scraper.pattern.scraper_request import ScraperRequest
 from scraper.pattern.scraper_result import DRUG_STORE
 from utils.vmd_utils import departementUtils
 
+MAPHARMA_HEADERS = {
+    'User-Agent': os.environ.get('MAPHARMA_API_KEY', ''),
+}
+
 timeout = httpx.Timeout(30.0, connect=30.0)
-DEFAULT_CLIENT = httpx.Client(timeout=timeout)
+DEFAULT_CLIENT = httpx.Client(timeout=timeout, headers=MAPHARMA_HEADERS)
 logger = logging.getLogger('scraper')
 
 insee = {}


### PR DESCRIPTION
Corrige https://github.com/CovidTrackerFr/vitemadose/issues/160

Après discussion avec des personnes travaillant chez Ma Pharma, un user agent personnalisé pourrait être intéressant pour identifier clairement le scraper ViteMaDose et éviter de ban les IPs de nos workers.

Variable à ajouter github/gitlab : MAPHARMA_API_KEY

cc @rozierguillaume 