### PR TITLE
[Bugfix] Unicité basée sur les urls + garde les pids dans les URLS

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -1,6 +1,7 @@
+from time import sleep, time
 from scraper.pattern.scraper_result import DRUG_STORE, GENERAL_PRACTITIONER, VACCINATION_CENTER
 from utils.vmd_utils import departementUtils, format_phone_number
-from utils.vmd_logger import enable_logger_for_production
+from utils.vmd_logger import get_logger
 from scraper.doctolib.doctolib import DOCTOLIB_HEADERS
 
 from typing import List
@@ -32,7 +33,7 @@ DOCTOLIB_DOMAINS = [
 ]
 
 
-logger = enable_logger_for_production()
+logger = get_logger()
 
 
 def parse_doctolib_centers() -> List[dict]:
@@ -55,7 +56,6 @@ def parse_doctolib_centers() -> List[dict]:
             f"[Doctolib centers] Parsing pages of departement {problematic_departement} through department SEO link")
         centers_departements = parse_pages_departement(
             problematic_departement)
-        print(centers_departements)
         centers += centers_departements
 
     return centers
@@ -100,7 +100,6 @@ def doctolib_urlify(departement: str) -> str:
 
 
 def parse_page_centers(page_id) -> List[dict]:
-    print(BASE_URL.format(page_id))
     r = requests.get(BASE_URL.format(page_id), headers=DOCTOLIB_HEADERS)
     data = r.json()
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -140,19 +140,11 @@ def export_data(centres_cherchés, outpath_format='data/output/{}.json'):
         for code in departementUtils.import_departements()
     }
 
-    internal_ids = []
+    # This should be duplicate free, they are already checked in
     for centre in centres_cherchés:
         centre.nom = centre.nom.strip()
         compte_centres += 1
         code_departement = centre.departement
-
-        # Check duplicates
-        if centre.internal_id:
-            if centre.internal_id in internal_ids:
-                logger.warning(
-                    f"le centre {centre.nom} ({code_departement}) est un doublon (ID interne: {centre.internal_id})")
-                continue
-            internal_ids.append(centre.internal_id)
 
         if code_departement not in par_departement:
             logger.warning(

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -23,20 +23,20 @@ class departementUtils:
     @staticmethod
     def import_departements() -> List[str]:
         """
-		Renvoie la liste des codes départements.
+                Renvoie la liste des codes départements.
 
-		>>> departements = import_departements()
-		>>> len(departements)
-		101
-		>>> departements[:3]
-		['01', '02', '03']
-		>>> departements[83]
-		'83'
-		>>> departements.index('2A')
-		28
-		>>> sorted(departements) == departements
-		True
-		"""
+                >>> departements = import_departements()
+                >>> len(departements)
+                101
+                >>> departements[:3]
+                ['01', '02', '03']
+                >>> departements[83]
+                '83'
+                >>> departements.index('2A')
+                28
+                >>> sorted(departements) == departements
+                True
+                """
         with open("data/input/departements-france.csv", newline="\n") as csvfile:
             reader = csv.DictReader(csvfile)
             return [str(row["code_departement"]) for row in reader]
@@ -44,18 +44,18 @@ class departementUtils:
     @staticmethod
     def to_departement_number(insee_code: str) -> str:
         """
-		Renvoie le numéro de département correspondant au code INSEE d'une commune.
+                Renvoie le numéro de département correspondant au code INSEE d'une commune.
 
-		Le code INSEE est un code à 5 chiffres, qui est typiquement différent du code postal,
-		mais qui commence (en général) aussi par les 2 chiffres du département.
+                Le code INSEE est un code à 5 chiffres, qui est typiquement différent du code postal,
+                mais qui commence (en général) aussi par les 2 chiffres du département.
 
-		>>> to_departement_number('59350')  # Lille
-		'59'
-		>>> to_departement_number('75106')  # Paris 6e arr
-		'75'
-		>>> to_departement_number('97701')  # Saint-Barthélémy
-		'971'
-		"""
+                >>> to_departement_number('59350')  # Lille
+                '59'
+                >>> to_departement_number('75106')  # Paris 6e arr
+                '75'
+                >>> to_departement_number('97701')  # Saint-Barthélémy
+                '971'
+                """
         if len(insee_code) == 4:
             # Quand le CSV des centres de vaccinations est édité avec un tableur comme Excel,
             # il est possible que le 1er zéro soit retiré si la colonne est interprétée comme
@@ -72,15 +72,16 @@ class departementUtils:
             return insee_to_code_departement_table[insee_code]["departement"]
 
         else:
-            raise ValueError(f'Code INSEE absent de la base des codes INSEE : {insee_code}')
+            raise ValueError(
+                f'Code INSEE absent de la base des codes INSEE : {insee_code}')
 
     @staticmethod
     def get_city(address: str) -> str:
         """
-		Récupère la ville depuis l'adresse complète
-		>>> get_city("2 avenue de la République, 75005 PARIS")
-		'PARIS'
-		"""
+                Récupère la ville depuis l'adresse complète
+                >>> get_city("2 avenue de la République, 75005 PARIS")
+                'PARIS'
+                """
         return re.search('(?<= \d{5} )(?P<com_nom>.*)\s*$', address).groupdict()['com_nom']
 
     @staticmethod
@@ -120,7 +121,8 @@ def fix_scrap_urls(url):
 
     # Fix Keldoc
     if url.startswith("https://www.keldoc.com/"):
-        url = url.replace("https://www.keldoc.com/", "https://vaccination-covid.keldoc.com/")
+        url = url.replace("https://www.keldoc.com/",
+                          "https://vaccination-covid.keldoc.com/")
     # Clean Doctolib
     if url.startswith('https://partners.doctolib.fr') or url.startswith('https://www.doctolib.fr'):
         u = urlparse(url)
@@ -131,7 +133,6 @@ def fix_scrap_urls(url):
                 to_remove.append(query_name)
         [query.pop(rm, None) for rm in to_remove]
         query.pop('speciality_id', None)
-        query.pop('pid', None)
         u = u._replace(query=urlencode(query, True))
         url = urlunparse(u)
     return url


### PR DESCRIPTION
Avant, tous les centres sous le même PID étaient traités comme uniques. Ce fix devrait  maintenant correctement rediriger vers le bon centre lorsqu'il a un PID. Il devrait aussi bien indexer les mêmes centres à PIDs différents.

(Notre code devient un peu bordélique, il y a trop de fois les choses faites)