### PR TITLE
Scrapping doctolib centers through departments

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -55,7 +55,7 @@ def get_departements():
     with open("data/input/departements-france.csv", newline="\n") as csvfile:
         reader = csv.DictReader(csvfile)
         departements = [str(row["nom_departement"]) for row in reader]
-        return [departement in departements if departement not in NOT_INCLUDED_DEPARTEMENTS]
+        [departements.pop(ndep) for ndep in NOT_INCLUDED_DEPARTEMENTS]
 
 
 def parse_pages_departement(departement):

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -56,6 +56,7 @@ def get_departements():
         reader = csv.DictReader(csvfile)
         departements = [str(row["nom_departement"]) for row in reader]
         [departements.pop(ndep) for ndep in NOT_INCLUDED_DEPARTEMENTS]
+        return departements
 
 
 def parse_pages_departement(departement):

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -47,6 +47,7 @@ def parse_doctolib_centers(page_limit=None) -> List[dict]:
         centers += centers_departements
     return centers
 
+
 def get_departements():
     import csv
 
@@ -55,7 +56,7 @@ def get_departements():
     with open("data/input/departements-france.csv", newline="\n") as csvfile:
         reader = csv.DictReader(csvfile)
         departements = [str(row["nom_departement"]) for row in reader]
-        [departements.pop(ndep) for ndep in NOT_INCLUDED_DEPARTEMENTS]
+        [departements.remove(ndep) for ndep in NOT_INCLUDED_DEPARTEMENTS]
         return departements
 
 

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -51,9 +51,13 @@ def parse_doctolib_centers() -> List[dict]:
 def get_departements():
     import csv
 
+    # Guyane uses Maiia and does not have doctolib pages
+    NOT_INCLUDED_DEPARTEMENTS = ["Guyane"]
+
     with open("data/input/departements-france.csv", newline="\n") as csvfile:
         reader = csv.DictReader(csvfile)
-        return [str(row["nom_departement"]) for row in reader]
+        departements = [str(row["nom_departement"]) for row in reader]
+        return [departement in departements if departement not in NOT_INCLUDED_DEPARTEMENTS]
 
 
 def parse_pages_departement(departement):
@@ -117,17 +121,28 @@ def center_from_doctor_dict(doctor_dict) -> dict:
     rdv_site_web = f"https://partners.doctolib.fr{url_path}"
     type = center_type(url_path, nom)
     dict_infos_center_page = get_dict_infos_center_page(url_path)
+    longitude, latitude = get_coordinates(doctor_dict)
     dict_infos_browse_page = {
         "nom": nom,
         "rdv_site_web": rdv_site_web,
         "ville": ville,
         "address": addresse,
-        "long_coor1": float(doctor_dict["position"]["lng"]),
-        "lat_coor1": float(doctor_dict["position"]["lat"]),
+        "long_coor1": longitude,
+        "lat_coor1": latitude,
         "type": type,
         "com_insee": departementUtils.cp_to_insee(code_postal)
     }
     return {**dict_infos_center_page, **dict_infos_browse_page}
+
+
+def get_coordinates(doctor_dict):
+    longitude = doctor_dict["position"]["lng"]
+    latitude = doctor_dict["position"]["lat"]
+    if longitude:
+        longitude = float(longitude)
+    if latitude:
+        latitude = float(latitude)
+    return longitude, latitude
 
 
 def get_dict_infos_center_page(url_path: str) -> dict:

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -38,27 +38,22 @@ logger = get_logger()
 
 def parse_doctolib_centers() -> List[dict]:
     centers = []
-
-    page_id = 1
-    page_has_centers = True
-    while page_has_centers:
-        logger.info(f"[Doctolib centers] Parsing page {page_id}")
-        centers_page = parse_page_centers(page_id)
-        centers += centers_page
-
-        page_id += 1
-
-        if len(centers_page) == 0:
-            page_has_centers = False
-
-    for problematic_departement in ["gers", "jura", "var"]:
+    for departement in get_departements():
         logger.info(
-            f"[Doctolib centers] Parsing pages of departement {problematic_departement} through department SEO link")
-        centers_departements = parse_pages_departement(
-            problematic_departement)
+            f"[Doctolib centers] Parsing pages of departement {departement} through department SEO link")
+        centers_departements = parse_pages_departement(departement)
+        if centers_departements == 0:
+            raise Exception("No Value found for department {}, crashing")
         centers += centers_departements
-
     return centers
+
+
+def get_departements():
+    import csv
+
+    with open("data/input/departements-france.csv", newline="\n") as csvfile:
+        reader = csv.DictReader(csvfile)
+        return [str(row["nom_departement"]) for row in reader]
 
 
 def parse_pages_departement(departement):
@@ -150,7 +145,8 @@ def get_dict_infos_center_page(url_path: str) -> dict:
 
         # Parse place location
         infos_page = {}
-        infos_page['gid'] = 'd{0}'.format(output.get('profile', {}).get('id', ''))
+        infos_page['gid'] = 'd{0}'.format(
+            output.get('profile', {}).get('id', ''))
         infos_page['address'] = place['full_address']
         infos_page['long_coor1'] = place.get('longitude')
         infos_page['lat_coor1'] = place.get('latitude')

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -1,6 +1,7 @@
+from time import sleep, time
 from scraper.pattern.scraper_result import DRUG_STORE, GENERAL_PRACTITIONER, VACCINATION_CENTER
 from utils.vmd_utils import departementUtils, format_phone_number
-from utils.vmd_logger import enable_logger_for_production
+from utils.vmd_logger import get_logger
 from scraper.doctolib.doctolib import DOCTOLIB_HEADERS
 
 from typing import List
@@ -32,7 +33,7 @@ DOCTOLIB_DOMAINS = [
 ]
 
 
-logger = enable_logger_for_production()
+logger = get_logger()
 
 
 def parse_doctolib_centers() -> List[dict]:
@@ -55,7 +56,6 @@ def parse_doctolib_centers() -> List[dict]:
             f"[Doctolib centers] Parsing pages of departement {problematic_departement} through department SEO link")
         centers_departements = parse_pages_departement(
             problematic_departement)
-        print(centers_departements)
         centers += centers_departements
 
     return centers
@@ -100,7 +100,6 @@ def doctolib_urlify(departement: str) -> str:
 
 
 def parse_page_centers(page_id) -> List[dict]:
-    print(BASE_URL.format(page_id))
     r = requests.get(BASE_URL.format(page_id), headers=DOCTOLIB_HEADERS)
     data = r.json()
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -263,7 +263,7 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
             centres_non_pris_en_compte["centres_fermes"][row["gid"]
                                                          ] = row["rdv_site_web"]
 
-        if len(row["rdv_site_web"]):
+        if len(row["rdv_site_web"]) and "doctolib" not in row["rdv_site_web"]:
             yield row
         else:
             centres_non_pris_en_compte["centres_urls_vides"].append(row["gid"])

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -140,19 +140,11 @@ def export_data(centres_cherchés, outpath_format='data/output/{}.json'):
         for code in departementUtils.import_departements()
     }
 
-    internal_ids = []
+    # This should be duplicate free, they are already checked in
     for centre in centres_cherchés:
         centre.nom = centre.nom.strip()
         compte_centres += 1
         code_departement = centre.departement
-
-        # Check duplicates
-        if centre.internal_id:
-            if centre.internal_id in internal_ids:
-                logger.warning(
-                    f"le centre {centre.nom} ({code_departement}) est un doublon (ID interne: {centre.internal_id})")
-                continue
-            internal_ids.append(centre.internal_id)
 
         if code_departement not in par_departement:
             logger.warning(

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
 
-from scraper.doctolib.doctolib_center_scrap import parse_doctolib_centers, get_departements, doctolib_urlify
+from scraper.doctolib.doctolib_center_scrap import parse_doctolib_centers, get_departements, doctolib_urlify, \
+    get_coordinates, center_from_doctor_dict, center_type, parse_doctolib_business_hours
 from scraper.error import BlockedByDoctolibError
 
 import httpx
@@ -17,6 +18,7 @@ from scraper.doctolib.doctolib import (
 
 # -- Tests de l'API (offline) --
 from scraper.pattern.scraper_request import ScraperRequest
+from scraper.pattern.scraper_result import GENERAL_PRACTITIONER, DRUG_STORE, VACCINATION_CENTER
 
 
 def test_doctolib_departements():
@@ -27,3 +29,40 @@ def test_doctolib_departements():
 def test_doctolib_urlify():
     url = 'FooBar 42'
     assert doctolib_urlify(url) == 'foobar-42'
+
+
+def test_center_type():
+    type = center_type('https://doctolib.fr/center/foobar-42', 'Pharmacie du centre de Saint-Malo')
+    assert type == DRUG_STORE
+    type = center_type('https://doctolib.fr/medecin/foobar-42', 'Dr Foo Bar')
+    assert type == GENERAL_PRACTITIONER
+    type = center_type('https://doctolib.fr/centres-vaccination/foobar-42', 'Centre Foo Bar')
+    assert type == VACCINATION_CENTER
+
+
+def test_business_hours():
+    place = {
+        'opening_hours': [
+            {
+                'day': 1,
+                'enabled': True,
+                'ranges': [
+                    ['12:00', '15:00'],
+                    ['16:00', '17:00'],
+                ]
+            }
+        ]
+    }
+    assert parse_doctolib_business_hours(place) == {'lundi': '12:00-15:00, 16:00-17:00'}
+
+
+def test_doctolib_coordinates():
+    docto = {
+        'position': {
+            'lng': 1.381,
+            'lat': 8.192
+        }
+    }
+    long, lat = get_coordinates(docto)
+    assert long == 1.381
+    assert lat == 8.192

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from scraper.doctolib.doctolib_center_scrap import parse_doctolib_centers
+from scraper.doctolib.doctolib_center_scrap import parse_doctolib_centers, get_departements, doctolib_urlify
 from scraper.error import BlockedByDoctolibError
 
 import httpx
@@ -15,11 +15,15 @@ from scraper.doctolib.doctolib import (
     DOCTOLIB_SLOT_LIMIT,
 )
 
-
 # -- Tests de l'API (offline) --
 from scraper.pattern.scraper_request import ScraperRequest
 
 
-def test_doctolib_scraper():
-    data = parse_doctolib_centers(page_limit=1)
-    assert len(data) > 0
+def test_doctolib_departements():
+    dep = get_departements()
+    assert len(dep) == 100
+
+
+def test_doctolib_urlify():
+    url = 'FooBar 42'
+    assert doctolib_urlify(url) == 'foobar-42'

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -23,20 +23,20 @@ class departementUtils:
     @staticmethod
     def import_departements() -> List[str]:
         """
-		Renvoie la liste des codes départements.
+                Renvoie la liste des codes départements.
 
-		>>> departements = import_departements()
-		>>> len(departements)
-		101
-		>>> departements[:3]
-		['01', '02', '03']
-		>>> departements[83]
-		'83'
-		>>> departements.index('2A')
-		28
-		>>> sorted(departements) == departements
-		True
-		"""
+                >>> departements = import_departements()
+                >>> len(departements)
+                101
+                >>> departements[:3]
+                ['01', '02', '03']
+                >>> departements[83]
+                '83'
+                >>> departements.index('2A')
+                28
+                >>> sorted(departements) == departements
+                True
+                """
         with open("data/input/departements-france.csv", newline="\n") as csvfile:
             reader = csv.DictReader(csvfile)
             return [str(row["code_departement"]) for row in reader]
@@ -44,18 +44,18 @@ class departementUtils:
     @staticmethod
     def to_departement_number(insee_code: str) -> str:
         """
-		Renvoie le numéro de département correspondant au code INSEE d'une commune.
+                Renvoie le numéro de département correspondant au code INSEE d'une commune.
 
-		Le code INSEE est un code à 5 chiffres, qui est typiquement différent du code postal,
-		mais qui commence (en général) aussi par les 2 chiffres du département.
+                Le code INSEE est un code à 5 chiffres, qui est typiquement différent du code postal,
+                mais qui commence (en général) aussi par les 2 chiffres du département.
 
-		>>> to_departement_number('59350')  # Lille
-		'59'
-		>>> to_departement_number('75106')  # Paris 6e arr
-		'75'
-		>>> to_departement_number('97701')  # Saint-Barthélémy
-		'971'
-		"""
+                >>> to_departement_number('59350')  # Lille
+                '59'
+                >>> to_departement_number('75106')  # Paris 6e arr
+                '75'
+                >>> to_departement_number('97701')  # Saint-Barthélémy
+                '971'
+                """
         if len(insee_code) == 4:
             # Quand le CSV des centres de vaccinations est édité avec un tableur comme Excel,
             # il est possible que le 1er zéro soit retiré si la colonne est interprétée comme
@@ -72,15 +72,16 @@ class departementUtils:
             return insee_to_code_departement_table[insee_code]["departement"]
 
         else:
-            raise ValueError(f'Code INSEE absent de la base des codes INSEE : {insee_code}')
+            raise ValueError(
+                f'Code INSEE absent de la base des codes INSEE : {insee_code}')
 
     @staticmethod
     def get_city(address: str) -> str:
         """
-		Récupère la ville depuis l'adresse complète
-		>>> get_city("2 avenue de la République, 75005 PARIS")
-		'PARIS'
-		"""
+                Récupère la ville depuis l'adresse complète
+                >>> get_city("2 avenue de la République, 75005 PARIS")
+                'PARIS'
+                """
         return re.search('(?<= \d{5} )(?P<com_nom>.*)\s*$', address).groupdict()['com_nom']
 
     @staticmethod
@@ -120,7 +121,8 @@ def fix_scrap_urls(url):
 
     # Fix Keldoc
     if url.startswith("https://www.keldoc.com/"):
-        url = url.replace("https://www.keldoc.com/", "https://vaccination-covid.keldoc.com/")
+        url = url.replace("https://www.keldoc.com/",
+                          "https://vaccination-covid.keldoc.com/")
     # Clean Doctolib
     if url.startswith('https://partners.doctolib.fr') or url.startswith('https://www.doctolib.fr'):
         u = urlparse(url)
@@ -131,7 +133,6 @@ def fix_scrap_urls(url):
                 to_remove.append(query_name)
         [query.pop(rm, None) for rm in to_remove]
         query.pop('speciality_id', None)
-        query.pop('pid', None)
         u = u._replace(query=urlencode(query, True))
         url = urlunparse(u)
     return url


### PR DESCRIPTION
It seems to yield more (all ?) centers (@grubounet)

Because of this, I removed dependence on opendata for doctolib, which should remove the duplicates on the site.

The scraping is slow (10+mn). It can be sped-up with multithreading. I'll let @grubounet add a PR on top of this.

CC @tlevillayer with whom we investigated