### PR TITLE
scraper.py -> use platform list to avoid csv

### DIFF
--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -300,9 +300,8 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
 
 def should_use_opendata_row(rdv_site_web: str) -> bool:
     plateformes_hors_csv = ['doctolib']
-    for plateforme in plateformes_hors_csv:
-        if plateforme in rdv_site_web:
-            return False
+    if any(p in rdv_site_web for p in plateformes_hors_csv):
+        return False
     return True
 
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -276,7 +276,7 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
         if row["centre_fermeture"] == "t":
             centres_non_pris_en_compte["centres_fermes"][row["gid"]
                                                          ] = row["rdv_site_web"]
-        if len(row["rdv_site_web"]) and "doctolib" not in row["rdv_site_web"]:
+        if should_use_opendata_row(row["rdv_site_web"]):
             yield row
         else:
             centres_non_pris_en_compte["centres_urls_vides"].append(row["gid"])
@@ -296,6 +296,14 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
     outpath = outpath_format.format("centres_non_pris_en_compte_gouv")
     with open(outpath, "w") as fichier:
         json.dump(centres_non_pris_en_compte, fichier, indent=2)
+
+
+def should_use_opendata_row(rdv_site_web: str) -> bool:
+    plateformes_hors_csv = ['doctolib']
+    for plateforme in plateformes_hors_csv:
+        if plateforme in rdv_site_web:
+            return False
+    return True
 
 
 def copy_omit_keys(d, omit_keys):

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -300,6 +300,7 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
 
 def should_use_opendata_csv(rdv_site_web: str) -> bool:
     plateformes_hors_csv = ['doctolib']
+    
     if any(p in rdv_site_web for p in plateformes_hors_csv):
         return False
     return True

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -276,7 +276,7 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
         if row["centre_fermeture"] == "t":
             centres_non_pris_en_compte["centres_fermes"][row["gid"]
                                                          ] = row["rdv_site_web"]
-        if should_use_opendata_row(row["rdv_site_web"]):
+        if should_use_opendata_csv(row["rdv_site_web"]):
             yield row
         else:
             centres_non_pris_en_compte["centres_urls_vides"].append(row["gid"])
@@ -298,7 +298,7 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
         json.dump(centres_non_pris_en_compte, fichier, indent=2)
 
 
-def should_use_opendata_row(rdv_site_web: str) -> bool:
+def should_use_opendata_csv(rdv_site_web: str) -> bool:
     plateformes_hors_csv = ['doctolib']
     if any(p in rdv_site_web for p in plateformes_hors_csv):
         return False


### PR DESCRIPTION
Pour aider à la migration des plateformes utilisant le csv vers un mode api (on cherche les centres directement sur les api de la plateforme et plus dans le csv), j'ai repris l'exclusion doctolib pour pouvoir ajouter des plateformes dans cette exclusion.
Il suffira donc d'ajouter un nom de plateforme (dans les faits la partie reconnaissable de son url) dans la liste plateformes_hors_csv 