### PR TITLE
Considère les agendas et pids pour un unique motif

### DIFF
--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -378,10 +378,10 @@ def test_find_agenda_and_practice_ids():
             ],
         },
     }
-    agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=[1])
+    agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=1)
     assert agenda_ids == ["10", "12"]
     assert practice_ids == ["20", "21", "24"]
 
-    agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=[1], practice_id_filter=[21])
+    agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=1, practice_id_filter=[21])
     assert agenda_ids == ["12"]
     assert practice_ids == ["21", "24"]


### PR DESCRIPTION
La logique précédent était un peu bancale et prennait tous les motifs possibles. Du coup, si un motif était présent dans la lsite des motifs pour un agenda, cet agenda était compté pour tous les motifs. En pratique, certains agendas ne sont disponnibles que pour certains motifs.

Corrige #215 