### PR TITLE
Modification du filtre campagnes

### DIFF
--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -172,6 +172,8 @@ def is_campagne_valid(campagne: dict) -> bool:
     global campagnes_valides
     if not campagne.get('url'):
         return False
+    if 'vaccination_covid' in campagne:
+        return campagne.get('vaccination_covid')
     if any(keyword in campagne.get('nom', 'erreur').lower() for keyword in MAPHARMA_CAMPAGNES_INVALIDES):
         return False
     if any(keyword in campagne.get('nom', 'erreur').lower() for keyword in MAPHARMA_CAMPAGNES_VALIDES):

--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -24,11 +24,16 @@ MAPHARMA_HEADERS = {
 
 MAPHARMA_CAMPAGNES_VALIDES = [
     'vaccination covid',
-    'vaccination covid19',
-    'vaccination covid-19',
-    'vaccination covid (vaccination covid - 1ère injection)',
-    'vaccination covid 1 injection',
     'covid 1ère injection'
+]
+
+MAPHARMA_CAMPAGNES_INVALIDES = [
+    'test antigenique',
+    'test antigénique',
+    'test sérologique',
+    'pilulier',
+    'diététique',
+    'nutrition'
 ]
 
 timeout = httpx.Timeout(30.0, connect=30.0)
@@ -167,7 +172,9 @@ def is_campagne_valid(campagne: dict) -> bool:
     global campagnes_valides
     if not campagne.get('url'):
         return False
-    if campagne.get('nom', 'erreur').lower() in MAPHARMA_CAMPAGNES_VALIDES:
+    if any(keyword in campagne.get('nom', 'erreur').lower() for keyword in MAPHARMA_CAMPAGNES_INVALIDES):
+        return False
+    if any(keyword in campagne.get('nom', 'erreur').lower() for keyword in MAPHARMA_CAMPAGNES_VALIDES):
         return True
     if not campagnes_valides:
         # on charge la liste des campagnes valides (vaccination)


### PR DESCRIPTION
LE responsable de mapharma vient de me remonter un problème de pharmacies qui n'apparaissent pas alors qu'elles ont des dispos. Le problème vient de l'intitulé de la campagne, mon seul moyen de faire la différence entre une campagne qui fait vraiment des vaccins et une campagne pour un autre sujet. Au lieu de comparer le nom complet de la campagne par rapport à mon filtre, je vais maintenant identifier des mots clés (injection covid) et aussi refuser les campagnes contenant certains mots clés (test antigénique)