### PR TITLE
fix #246

### DIFF
--- a/scraper/doctolib/doctolib_filters.py
+++ b/scraper/doctolib/doctolib_filters.py
@@ -23,6 +23,7 @@ DOCTOLIB_CATEGORY = [
     'vaccination pfizer',
     'grand public',
     'personnes de plus de',
+    'personnes de 60 ans et plus',
     'vaccination covid',  # 50 - 55 ans avec comoribidtés
     'Pfizer',
     'Astra Zeneca',


### PR DESCRIPTION
catégorie de rendez-vous qui n'est pas présente dans le filtre, ce qui provoque un abandon du scraper sans remonter les dispo