### PR TITLE
mapharma corrections fallback opendata & tests

### DIFF
--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -89,7 +89,7 @@ def get_mapharma_opendata(
         request = client.get(opendata_url, headers=MAPHARMA_HEADERS)
         request.raise_for_status()
         return request.json()
-    except TimeoutException as hex:
+    except httpx.TimeoutException as hex:
         logger.warning(f"{opendata_url} timed out {hex}")
     except httpx.HTTPStatusError as hex:
         logger.warning(f'{opendata_url} returned error {hex.response.status_code}')
@@ -107,7 +107,7 @@ def get_pharmacy_and_campagne(
     id_campagne: int, 
     id_type: int, 
     opendata_file: str = MAPHARMA_OPEN_DATA_FILE) -> [dict, dict]:
-    opendate = list
+    opendata = list() 
     try:
         with open(opendata_file, 'r', encoding='utf8') as f:
             opendata = json.load(f)

--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -1,7 +1,6 @@
 import os
 
 import httpx
-from httpx import TimeoutException
 import json
 import logging
 
@@ -38,8 +37,7 @@ MAPHARMA_CAMPAGNES_INVALIDES = [
 
 MAPHARMA_OPEN_DATA_FILE = Path('data', 'output', 'mapharma_open_data.json')
 MAPHARMA_OPEN_DATA_URL = 'https://mapharma.net/opendata/rdv'
-MAPHARMA_OPEN_DATA_URL_FALLBACK = 
-    'https://raw.githubusercontent.com/CovidTrackerFr/vitemadose/data-auto/data/output/mapharma_open_data.json'
+MAPHARMA_OPEN_DATA_URL_FALLBACK = 'https://raw.githubusercontent.com/CovidTrackerFr/vitemadose/data-auto/data/output/mapharma_open_data.json'
 
 timeout = httpx.Timeout(30.0, connect=30.0)
 DEFAULT_CLIENT = httpx.Client(timeout=timeout, headers=MAPHARMA_HEADERS)
@@ -91,20 +89,18 @@ def get_mapharma_opendata(
         request = client.get(opendata_url, headers=MAPHARMA_HEADERS)
         request.raise_for_status()
         return request.json()
-    except httpx.TimeoutException as hex:
-        logger.warning(f"{opendata_url} timed out {hex}"
+    except TimeoutException as hex:
+        logger.warning(f"{opendata_url} timed out {hex}")
     except httpx.HTTPStatusError as hex:
-        logger.warning(
-            f'{opendata_url} returned error {hex.response.status_code}')
+        logger.warning(f'{opendata_url} returned error {hex.response.status_code}')
     try:
         request = client.get(opendata_url_fallback, headers=MAPHARMA_HEADERS)
         request.raise_for_status()
         return request.json()
     except httpx.TimeoutException as hex:
-        logger.warning(f"{opendata_url_fallback} timed out {hex}"
+        logger.warning(f"{opendata_url_fallback} timed out {hex}")
     except httpx.HTTPStatusError as hex:
-        logger.warning(
-            f'{opendata_url_fallback} returned error {hex.response.status_code}')
+        logger.warning(f'{opendata_url_fallback} returned error {hex.response.status_code}')
     return None
 
 def get_pharmacy_and_campagne(
@@ -133,7 +129,8 @@ def get_slots(
         r = client.get(base_url)
         r.raise_for_status()
     except httpx.TimeoutException as hex:
-        logger.warning(f"{base_url} timed out {hex}"
+        logger.warning(f"{base_url} timed out {hex}")
+        return {}
     except httpx.HTTPStatusError as hex:
         logger.warning(f'{base_url} returned error {hex.response.status_code}')
         return {}

--- a/tests/fixtures/mapharma/mapharma_open_data.json
+++ b/tests/fixtures/mapharma/mapharma_open_data.json
@@ -1,0 +1,256 @@
+[
+  {
+    "nom": "Pharmacie De Saint Quentin",
+    "adresse": "4 rue de la Chauss\u00e9e Romaine",
+    "code_postal": "02100",
+    "ville": "SAINT QUENTIN",
+    "latitude": 49.844111,
+    "longitude": 3.275341,
+    "telephone": "",
+    "horaires": "lundi: 08:30 \u2013 12:30, 13:30 \u2013 18:00\nmardi: 08:30 \u2013 12:30, 13:30 \u2013 18:00\nmercredi: 08:30 \u2013 12:30, 13:30 \u2013 18:00\njeudi: 08:30 \u2013 12:30, 13:30 \u2013 18:00\nvendredi: 08:30 \u2013 12:30, 13:30 \u2013 18:00\nsamedi: 08:30 \u2013 12:30, 14:00 \u2013 17:00\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/02100-2",
+    "campagnes": [
+      {
+        "id_campagne": 93,
+        "id_type": 1,
+        "nom": "VACCINATION COVID",
+        "debut": "2021-03-23",
+        "fin": "2021-08-11",
+        "prochain_libre": "2021-04-14 09:00",
+        "total_libres": 7,
+        "url": "https://mapharma.net/02100-2?c=93&l=1"
+      },
+      {
+        "id_campagne": 217,
+        "id_type": 1,
+        "nom": "Test Antig\u00e9nique COVID19",
+        "debut": "2021-04-14",
+        "fin": "2021-08-31",
+        "prochain_libre": "2021-04-18 10:19",
+        "total_libres": 0,
+        "url": "https://mapharma.net/02100-2?c=217&l=1"
+      }
+    ]
+  },
+  {
+    "nom": "Pharmacie Bleas German",
+    "adresse": "26 Bld Paul Doumer",
+    "code_postal": "14780",
+    "ville": "LION SUR MER",
+    "latitude": 49.301801,
+    "longitude": -0.318003,
+    "telephone": "",
+    "horaires": "lundi: 09:00 \u2013 12:15, 14:00 \u2013 19:30\nmardi: 09:00 \u2013 12:15, 14:00 \u2013 19:30\nmercredi: 09:00 \u2013 12:15, 14:00 \u2013 19:30\njeudi: 09:00 \u2013 12:15, 14:00 \u2013 19:30\nvendredi: 09:00 \u2013 12:15, 14:00 \u2013 19:30\nsamedi: 09:00 \u2013 12:15, 14:00 \u2013 19:30\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/14780",
+    "campagnes": [
+      {
+        "id_campagne": 106,
+        "id_type": 1,
+        "nom": "RDV 2 Vaccin astrazeneca",
+        "debut": "2021-05-10",
+        "fin": "2021-12-31",
+        "prochain_libre": "2021-04-14 14:00",
+        "total_libres": 355,
+        "url": "https://mapharma.net/14780?c=106&l=1"
+      }
+    ]
+  },
+  {
+    "nom": "Pharmacie Saint Vincent",
+    "adresse": "6 rue Porte Lucas",
+    "code_postal": "51200",
+    "ville": "EPERNAY",
+    "latitude": 49.045056,
+    "longitude": 3.954369,
+    "telephone": "",
+    "horaires": "lundi: 08:30 \u2013 19:30\nmardi: 08:30 \u2013 19:30\nmercredi: 08:30 \u2013 12:30, 13:30 \u2013 19:30\njeudi: 08:30 \u2013 19:30\nvendredi: 08:30 \u2013 19:30\nsamedi: 08:30 \u2013 12:30, 13:30 \u2013 19:00\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/51200",
+    "campagnes": [
+      {
+        "id_campagne": 155,
+        "id_type": 1,
+        "nom": "Vaccination AZ 2(25 et 26/03)",
+        "debut": "2021-06-17",
+        "fin": "2021-06-18",
+        "prochain_libre": "2021-06-17",
+        "total_libres": 24,
+        "url": "https://mapharma.net/51200?c=155&l=1"
+      }
+    ]
+  },
+  {
+    "nom": "Pharmacie De Monchy",
+    "adresse": "2 avenue Foch",
+    "code_postal": "57730",
+    "ville": "FOLSCHVILLER",
+    "latitude": 49.070592,
+    "longitude": 6.686483,
+    "telephone": "",
+    "horaires": "lundi: 08:30 \u2013 12:00, 14:00 \u2013 19:00\nmardi: 08:30 \u2013 12:00, 14:00 \u2013 19:00\nmercredi: 08:30 \u2013 12:00, 14:00 \u2013 19:00\njeudi: 08:30 \u2013 12:00, 14:00 \u2013 19:00\nvendredi: 08:30 \u2013 12:00, 14:00 \u2013 19:00\nsamedi: 08:30 \u2013 12:00, 14:00 \u2013 18:00\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/57730",
+    "campagnes": [
+      {
+        "id_campagne": 48,
+        "id_type": 1,
+        "nom": "Vaccination Covid19",
+        "debut": "2021-03-22",
+        "fin": "2021-06-10",
+        "prochain_libre": "2021-04-18 00:00",
+        "total_libres": 158,
+        "url": "https://mapharma.net/57730?c=48&l=1"
+      }
+    ]
+  },
+  {
+    "nom": "Pharmacie Du Pont De L'Europe",
+    "adresse": "9 Rue de l'Abb\u00e9 Fran\u00e7ois Xavier Scherer",
+    "code_postal": "67000",
+    "ville": "STRASBOURG",
+    "latitude": 48.571632,
+    "longitude": 7.795583,
+    "telephone": "",
+    "horaires": "lundi: 09:00 \u2013 18:00\nmardi: 09:00 \u2013 18:00\nmercredi: 09:00 \u2013 18:00\njeudi: 09:00 \u2013 18:00\nvendredi: 09:00 \u2013 18:00\nsamedi: 09:00 \u2013 13:00\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/67000",
+    "campagnes": [
+      {
+        "id_campagne": 120,
+        "id_type": 1,
+        "nom": "Tests Covid19 (Test Antig\u00e9nique)",
+        "debut": "2021-03-15",
+        "fin": "2021-12-31",
+        "prochain_libre": "2021-04-14 09:30",
+        "total_libres": 2119,
+        "url": "https://mapharma.net/67000?c=120&l=1"
+      },
+      {
+        "id_campagne": 120,
+        "id_type": 2,
+        "nom": "Tests Covid19 (Test S\u00e9rologique)",
+        "debut": "2021-03-15",
+        "fin": "2021-12-31",
+        "prochain_libre": "2021-04-14 09:30",
+        "total_libres": 2119,
+        "url": "https://mapharma.net/67000?c=120&l=2"
+      }
+    ]
+  },
+  {
+    "nom": "Pharma 6",
+    "adresse": "230-232 rue de Belfort",
+    "code_postal": "68200",
+    "ville": "MULHOUSE",
+    "latitude": 47.738914,
+    "longitude": 7.295446,
+    "telephone": "",
+    "horaires": "lundi: 08:00 \u2013 20:00\nmardi: 08:00 \u2013 20:00\nmercredi: 08:00 \u2013 20:00\njeudi: 08:00 \u2013 20:00\nvendredi: 08:00 \u2013 20:00\nsamedi: 08:00 \u2013 18:00\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/68200",
+    "campagnes": [
+      {
+        "id_campagne": 210,
+        "id_type": 1,
+        "nom": "Vaccination Covid 2eme injection",
+        "debut": "2021-05-11",
+        "fin": "2021-05-11",
+        "prochain_libre": "2021-05-11 10:00",
+        "total_libres": 12,
+        "url": "https://mapharma.net/68200?c=210&l=1"
+      }
+    ]
+  },
+  {
+    "nom": "Pharmacie Des Lacs",
+    "adresse": "158 rue de l'H\u00f4tel de Ville",
+    "code_postal": "88400",
+    "ville": "XONRUPT LONGEMER",
+    "latitude": 48.083113,
+    "longitude": 6.9266,
+    "telephone": "",
+    "horaires": "lundi: 09:00 \u2013 12:00, 14:00 \u2013 18:00\nmardi: 09:00 \u2013 12:00, 14:00 \u2013 18:00\nmercredi: 09:00 \u2013 12:00, 14:00 \u2013 18:00\njeudi: 09:00 \u2013 12:00, 14:00 \u2013 18:00\nvendredi: 09:00 \u2013 12:00, 14:00 \u2013 18:00\nsamedi: 09:00 \u2013 12:00\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/88400",
+    "campagnes": [
+      {
+        "id_campagne": 92,
+        "id_type": 1,
+        "nom": "Vaccination Covid-19",
+        "debut": "2021-03-22",
+        "fin": "2021-04-30",
+        "prochain_libre": "2021-04-18",
+        "total_libres": 0,
+        "url": "https://mapharma.net/88400?c=92&l=1"
+      }
+    ]
+  },
+  {
+    "nom": "Pharmacie Gely Kst",
+    "adresse": "angle rue Lamartine & Isambert",
+    "code_postal": "97200",
+    "ville": "FORT DE FRANCE",
+    "latitude": 14.606159,
+    "longitude": -61.071282,
+    "telephone": "",
+    "horaires": "lundi: 07:30 \u2013 18:00\nmardi: 07:30 \u2013 18:00\nmercredi: 07:30 \u2013 18:00\njeudi: 07:30 \u2013 18:00\nvendredi: 07:30 \u2013 18:00\nsamedi: 07:30 \u2013 16:00\ndimanche: Ferm\u00e9",
+    "url": "https://mapharma.net/97200",
+    "campagnes": [
+      {
+        "id_campagne": 60,
+        "id_type": 1,
+        "nom": "Vaccination covid 1 injection",
+        "debut": "2021-03-29",
+        "fin": "2021-05-15",
+        "prochain_libre": "2021-04-14 08:00",
+        "total_libres": 216,
+        "url": "https://mapharma.net/97200?c=60&l=1"
+      },
+      {
+        "id_campagne": 81,
+        "id_type": 1,
+        "nom": "Entretien di\u00e9t\u00e9tique",
+        "debut": "2021-03-11",
+        "fin": "2022-12-31",
+        "prochain_libre": "2021-04-14",
+        "total_libres": 320,
+        "url": "https://mapharma.net/97200?c=81&l=1"
+      },
+      {
+        "id_campagne": 82,
+        "id_type": 1,
+        "nom": "Entretien micro nutrition aroma",
+        "debut": "2021-03-12",
+        "fin": "2022-12-30",
+        "prochain_libre": "2021-04-16",
+        "total_libres": 503,
+        "url": "https://mapharma.net/97200?c=82&l=1"
+      },
+      {
+        "id_campagne": 193,
+        "id_type": 1,
+        "nom": "Test Antigeniques COVID Naso-Pharynges",
+        "debut": "2021-04-01",
+        "fin": "2021-12-31",
+        "prochain_libre": "2021-04-14",
+        "total_libres": 2627,
+        "url": "https://mapharma.net/97200?c=193&l=1"
+      },
+      {
+        "id_campagne": 196,
+        "id_type": 1,
+        "nom": "Test Covid TROC Sanguins",
+        "debut": "2021-04-01",
+        "fin": "2021-12-31",
+        "prochain_libre": "2021-04-14",
+        "total_libres": 2512,
+        "url": "https://mapharma.net/97200?c=196&l=1"
+      },
+      {
+        "id_campagne": 203,
+        "id_type": 1,
+        "nom": "PILULIERS",
+        "debut": "2021-04-01",
+        "fin": "2021-12-31",
+        "prochain_libre": "2021-04-14 08:00",
+        "total_libres": 6620,
+        "url": "https://mapharma.net/97200?c=203&l=1"
+      }
+    ]
+  }
+]

--- a/tests/test_mapharma.py
+++ b/tests/test_mapharma.py
@@ -8,10 +8,12 @@ from datetime import datetime
 from scraper.mapharma.mapharma import parse_slots, fetch_slots
 from scraper.pattern.scraper_request import ScraperRequest
 
+TEST_OPEN_DATA_FILE = Path('tests', 'fixtures', 'mapharma', 'mapharma_open_data.json')
+TEST_SLOT_FILE = Path('tests', 'fixtures', 'mapharma', 'slots.json')
 
 def test_parse_slots():
     slots = dict()
-    with open(Path('tests', 'fixtures', 'mapharma', 'slots.json'), 'r', encoding='utf8') as f:
+    with open(TEST_SLOT_FILE, 'r', encoding='utf8') as f:
         slots = json.load(f)
     first_availability, slots_count = parse_slots(slots)
     assert first_availability == datetime(2021, 4, 19, 17, 15)
@@ -20,6 +22,7 @@ def test_parse_slots():
 
 def test_fetch_slots():
     def app(request: httpx.Request) -> httpx.Response:
+        print(request.url)
         try:
             with open(Path('tests', 'fixtures', 'mapharma', 'slots.json'), encoding='utf8') as f:
                 return httpx.Response(200, content=f.read())
@@ -30,5 +33,5 @@ def test_fetch_slots():
 
     request = ScraperRequest(
         'https://mapharma.net/97200?c=60&l=1', '2021-04-14')
-    first_availability = fetch_slots(request, client)
+    first_availability = fetch_slots(request, client, opendata_file = TEST_OPEN_DATA_FILE)
     assert first_availability == "2021-04-19T17:15:00"

--- a/tests/test_mapharma.py
+++ b/tests/test_mapharma.py
@@ -22,7 +22,6 @@ def test_parse_slots():
 
 def test_fetch_slots():
     def app(request: httpx.Request) -> httpx.Response:
-        print(request.url)
         try:
             with open(Path('tests', 'fixtures', 'mapharma', 'slots.json'), encoding='utf8') as f:
                 return httpx.Response(200, content=f.read())


### PR DESCRIPTION
j'ai corrigé le fallback opendata de mapharma. L'idée de ce fallback est d'utiliser la dernière version sauvegardée si l'API opendata ne répond pas. Le fallback allait chercher un fichier dans data/output mais en fait doit aller le chercher sur la branche data-auto
J'en ai profité pour ajouter des shims supplémentaires pour les tests unitaires qui étaient un peu faussés (enfin un peu sur le live en fait)