### PR TITLE
keldoc: timetables par agenda

### DIFF
--- a/scraper/keldoc/keldoc.py
+++ b/scraper/keldoc/keldoc.py
@@ -14,17 +14,9 @@ KELDOC_HEADERS = {
 }
 session = httpx.Client(timeout=timeout, headers=KELDOC_HEADERS)
 
-KELDOC_SLOT_LIMIT = 21
-
 
 @Profiling.measure('keldoc_slot')
 def fetch_slots(request: ScraperRequest):
-    # Keldoc needs an end date, but if no appointment are found,
-    # it still returns the next available appointment. Bigger end date
-    # makes Keldoc responses slower.
-    date_obj = datetime.strptime(request.get_start_date(), '%Y-%m-%d')
-    end_date = (date_obj + timedelta(days=KELDOC_SLOT_LIMIT)).strftime('%Y-%m-%d')
-
     center = KeldocCenter(request, client=session)
     # Unable to parse center resources (id, location)?
     if not center.parse_resource():
@@ -39,7 +31,7 @@ def fetch_slots(request: ScraperRequest):
     center.vaccine_motives = filter_vaccine_motives(session, center.selected_cabinet, center.id,
                                                     center.vaccine_specialties, center.vaccine_cabinets)
     # Find the first availability
-    date, count = center.find_first_availability(request.get_start_date(), end_date)
+    date, count = center.find_first_availability(request.get_start_date())
     if not date:
         request.update_appointment_count(0)
         return None

--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -1,7 +1,8 @@
 import logging
 import os
 from urllib.parse import urlsplit, parse_qs
-
+from datetime import datetime, timedelta
+from dateutil.parser import isoparse
 import httpx
 
 from scraper.keldoc.keldoc_filters import parse_keldoc_availability
@@ -12,6 +13,7 @@ timeout = httpx.Timeout(25.0, connect=25.0)
 KELDOC_HEADERS = {
     'User-Agent': os.environ.get('KELDOC_API_KEY', ''),
 }
+KELDOC_SLOT_LIMIT = 7
 DEFAULT_CLIENT = httpx.Client(timeout=timeout, headers=KELDOC_HEADERS)
 logger = logging.getLogger('scraper')
 
@@ -110,6 +112,51 @@ class KeldocCenter:
         }
         return True
 
+    
+    def get_timetables(self, start_date, end_date, motive_id, agenda_id):
+        calendar_url = API_KELDOC_CALENDAR.format(motive_id)
+        calendar_params = {
+            'from': start_date,
+            'to': start_date,
+            'agenda_ids[]': agenda_id
+        }
+        try:
+            calendar_req = self.client.get(calendar_url, params=calendar_params)
+            calendar_req.raise_for_status()
+        except httpx.TimeoutException as hex:
+            logger.warning(f"Keldoc request timed out for center: {self.base_url} (calendar request)"
+                f' calendar_url: {calendar_url}'
+                f' calendar_params: {calendar_params}')
+            return None
+        except httpx.HTTPStatusError as hex:
+            logger.warning(f"Keldoc request returned error {hex.response.status_code} "
+                        f"for center: {self.base_url} (calendar request)")
+            return None
+        calendar_json = calendar_req.json()
+        if 'date' in calendar_json:
+            new_date = isoparse(calendar_json['date'])
+            start_date = new_date.strftime('%Y-%m-%d')
+            end_date = (new_date + timedelta(days=KELDOC_SLOT_LIMIT)).strftime('%Y-%m-%d')
+        calendar_params = {
+            'from': start_date,
+            'to': end_date,
+            'agenda_ids[]': agenda_id
+        }
+        try:
+            calendar_req = self.client.get(calendar_url, params=calendar_params)
+            calendar_req.raise_for_status()
+        except httpx.TimeoutException as hex:
+            logger.warning(f"Keldoc request timed out for center: {self.base_url} (calendar request)"
+                f' celendar_url: {calendar_url}'
+                f' calendar_params: {calendar_params}')
+            return None
+        except httpx.HTTPStatusError as hex:
+            logger.warning(f"Keldoc request returned error {hex.response.status_code} "
+                        f"for center: {self.base_url} (calendar request)")
+            return None
+        return calendar_req.json()
+
+
     def find_first_availability(self, start_date, end_date):
         if not self.vaccine_motives:
             return None, 0
@@ -122,26 +169,14 @@ class KeldocCenter:
                 continue
             motive_id = relevant_motive.get('id', None)
             calendar_url = API_KELDOC_CALENDAR.format(motive_id)
-            calendar_params = {
-                'from': start_date,
-                'to': end_date,
-                'agenda_ids[]': relevant_motive.get('agendas', [])
-            }
-            try:
-                calendar_req = self.client.get(calendar_url, params=calendar_params)
-                calendar_req.raise_for_status()
-            except httpx.TimeoutException as hex:
-                logger.warning(f"Keldoc request timed out for center: {self.base_url} (calendar request)")
-                continue
-            except httpx.HTTPStatusError as hex:
-                logger.warning(f"Keldoc request returned error {hex.response.status_code} "
-                               f"for center: {self.base_url} (calendar request)")
-                continue
-            date, appointments = parse_keldoc_availability(calendar_req.json(), appointments)
-            if date is None:
-                continue
-            self.request.add_vaccine_type(relevant_motive.get('vaccine_type'))
-            # Compare first available date
-            if first_availability is None or date < first_availability:
-                first_availability = date
+
+            for agenda_id in relevant_motive.get('agendas', []):
+                timetables = self.get_timetables(start_date, end_date, motive_id, agenda_id)
+                date, appointments = parse_keldoc_availability(timetables, appointments)
+                if date is None:
+                    continue
+                self.request.add_vaccine_type(relevant_motive.get('vaccine_type'))
+                # Compare first available date
+                if first_availability is None or date < first_availability:
+                    first_availability = date
         return first_availability, len(appointments)

--- a/tests/test_keldoc.py
+++ b/tests/test_keldoc.py
@@ -86,10 +86,10 @@ def test_keldoc_parse_center():
     assert motives == json.loads(Path("tests", "fixtures", "keldoc", "center1-motives.json").read_text())
 
     # Find first availability date
-    date, count = test_center_1.find_first_availability("2020-04-04", "2020-04-05")
+    date, count = test_center_1.find_first_availability("2020-04-04")
     assert not date
     test_center_1.vaccine_motives = motives
-    date, count = test_center_1.find_first_availability("2020-04-04", "2020-04-05")
+    date, count = test_center_1.find_first_availability("2020-04-04")
     tz = datetime.timezone(datetime.timedelta(seconds=7200))
     assert date == datetime.datetime(2021, 4, 20, 16, 55, tzinfo=tz)
 


### PR DESCRIPTION
2 modifications afin de moins stresser l'api keldoc, suite aux conseils de notre contact chez Keldoc. Cela va aussi permettre d'éviter les timeouts pour la première modification et d'accélérer la recherche des timetables pour la seconde

- au lieu de demander les slots pour une collection d'agendas, on fait une requête par agenda. Cela fait forcément plus de requêtes mais évite les requêtes trop lourdes qui peuvent échouer
- Pour récupérer les slots, on doit préciser une fourchette de dates. La version actuelle fait une seule demande sur une fourchette de 21 jours partant du jour courant. J'ai remplacé ça par une première requête qui demande les slots du jour courant. S'il n'y a pas de dispo ce jour là on reçoit la date de la prochaine dispo. On ajuste alors la start_date à la date reçue. Une fois cette étape passé on relance la demande (avec start_date inchangée ou ajustée à la prochaine date de dispo) avec une fourchette de seulement 7 jours. Comparé à la version actuelle cela permet d'alléger la requête (moins de jours = une requête qui répond plus vite) et de trouver des dispo même si la première est au dela de 21 jours. Par contre on ne récupère qu'une semaine de slots au lieu de 21 jours, mais en contrepartie on a moins d'échec.