### PR TITLE
Ordoclic: Fix #256 (plus aucun centre ne remonte)

### DIFF
--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -25,9 +25,15 @@ def search(client: httpx.Client = DEFAULT_CLIENT):
     # toutes les pharmacies
     # payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true'}
     # toutes les pharmacies faisant des vaccins
-    payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 'in.isCovidVaccineSupported': 'true'}
+    # payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 'in.isCovidVaccineSupported': 'true'}
     # toutes les pharmacies faisant des vaccins avec des calendriers en ligne
     # payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 'in.isCovidVaccineSupported': 'true', 'in.covidOnlineBookingAvailabilities.covidInjection1': 'true' }
+    # toutes les pharmacies faisant du Pfizer ou de l'AstraZeneca
+    payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 
+               'in.isCovidVaccineSupported': 'true', 
+               'in.covidOnlineBookingAvailabilities.covidInjection1': 'true', 
+               'or.covidOnlineBookingAvailabilities.Vaccinarion Pfizer': 'true', 
+               'or.covidOnlineBookingAvailabilities.Vaccination AstraZeneca': 'true' }
     r = client.get(base_url, params=payload)
     r.raise_for_status()
     return r.json()

--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -136,7 +136,6 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
 
 def centre_iterator():
     items = search()
-    print(f'centers found: {len(items["items"])}')
     for item in items["items"]:
         # plusieur types possibles (pharmacie, maison mediacle, pharmacien, medecin, ...), pour l'instant on filtre juste les pharmacies
         if 'type' in item:

--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -31,7 +31,6 @@ def search(client: httpx.Client = DEFAULT_CLIENT):
     # toutes les pharmacies faisant du Pfizer ou de l'AstraZeneca
     payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 
                'in.isCovidVaccineSupported': 'true', 
-               'in.covidOnlineBookingAvailabilities.covidInjection1': 'true', 
                'or.covidOnlineBookingAvailabilities.Vaccinarion Pfizer': 'true', 
                'or.covidOnlineBookingAvailabilities.Vaccination AstraZeneca': 'true' }
     r = client.get(base_url, params=payload)

--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -25,9 +25,9 @@ def search(client: httpx.Client = DEFAULT_CLIENT):
     # toutes les pharmacies
     # payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true'}
     # toutes les pharmacies faisant des vaccins
-    # payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 'in.isCovidVaccineSupported': 'true'}
+    payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 'in.isCovidVaccineSupported': 'true'}
     # toutes les pharmacies faisant des vaccins avec des calendriers en ligne
-    payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 'in.isCovidVaccineSupported': 'true', 'in.covidOnlineBookingAvailabilities.covidInjection1': 'true' }
+    # payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 'in.isCovidVaccineSupported': 'true', 'in.covidOnlineBookingAvailabilities.covidInjection1': 'true' }
     r = client.get(base_url, params=payload)
     r.raise_for_status()
     return r.json()

--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -31,7 +31,7 @@ def search(client: httpx.Client = DEFAULT_CLIENT):
     # toutes les pharmacies faisant du Pfizer ou de l'AstraZeneca
     payload = {'page': '1', 'per_page': '10000', 'in.isPublicProfile': 'true', 
                'in.isCovidVaccineSupported': 'true', 
-               'or.covidOnlineBookingAvailabilities.Vaccinarion Pfizer': 'true', 
+               'or.covidOnlineBookingAvailabilities.Vaccination Pfizer': 'true', 
                'or.covidOnlineBookingAvailabilities.Vaccination AstraZeneca': 'true' }
     r = client.get(base_url, params=payload)
     r.raise_for_status()
@@ -136,6 +136,7 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
 
 def centre_iterator():
     items = search()
+    print(f'centers found: {len(items["items"])}')
     for item in items["items"]:
         # plusieur types possibles (pharmacie, maison mediacle, pharmacien, medecin, ...), pour l'instant on filtre juste les pharmacies
         if 'type' in item:


### PR DESCRIPTION
retrait du filtre in.covidOnlineBookingAvailabilities.covidInjection1 qui semble ne plus fonctionner avec la dernière mise à jour de l'API Ordoclic, la recherche ne renvoie plus aucun centre si on active ce filtre

Resolve #256 