### PR TITLE
Calcul des disponibilités à 24h et 7j pour doctolib (implémentation #265)

### DIFF
--- a/scraper/doctolib/doctolib.py
+++ b/scraper/doctolib/doctolib.py
@@ -131,7 +131,7 @@ class DoctolibSlots:
                     if not first_availability or sdate < first_availability:
                         first_availability = sdate
                     request.update_appointment_count(request.appointment_count + appt)
-                    request.update_next_appointments(count_next_appt)
+                    request.update_appointment_schedules(count_next_appt)
 
         return first_availability
 

--- a/scraper/pattern/center_info.py
+++ b/scraper/pattern/center_info.py
@@ -57,6 +57,7 @@ class CenterInfo:
         self.plateforme = None
         self.type = None
         self.appointment_count = 0
+        self.appointment_schedules={}
         self.internal_id = None
         self.vaccine_type = None
         self.appointment_by_phone_only = False
@@ -71,6 +72,7 @@ class CenterInfo:
         self.plateforme = result.platform
         self.type = result.request.practitioner_type
         self.appointment_count = result.request.appointment_count
+        self.appointment_schedules=result.request.appointment_schedules
         self.internal_id = result.request.internal_id
         self.vaccine_type = result.request.vaccine_type
         self.appointment_by_phone_only = result.request.appointment_by_phone_only

--- a/scraper/pattern/scraper_request.py
+++ b/scraper/pattern/scraper_request.py
@@ -18,8 +18,8 @@ class ScraperRequest:
     def update_appointment_count(self, appointment_count):
         self.appointment_count = appointment_count
 
-    def update_appointment_schedules(self, count_next_appt):
-        self.appointment_schedules=count_next_appt
+    def update_appointment_schedules(self, appointment_schedules):
+        self.appointment_schedules=appointment_schedules
 
 
     def add_vaccine_type(self, vaccine_name):

--- a/scraper/pattern/scraper_request.py
+++ b/scraper/pattern/scraper_request.py
@@ -5,6 +5,7 @@ class ScraperRequest:
         self.internal_id = None
         self.practitioner_type = None
         self.appointment_count = 0
+        self.appointment_schedules={}
         self.vaccine_type = None
         self.appointment_by_phone_only = False
 
@@ -16,6 +17,10 @@ class ScraperRequest:
 
     def update_appointment_count(self, appointment_count):
         self.appointment_count = appointment_count
+
+    def update_next_appointments(self, count_next_appt):
+        self.appointment_schedules=count_next_appt
+
 
     def add_vaccine_type(self, vaccine_name):
         if not vaccine_name:

--- a/scraper/pattern/scraper_request.py
+++ b/scraper/pattern/scraper_request.py
@@ -18,7 +18,7 @@ class ScraperRequest:
     def update_appointment_count(self, appointment_count):
         self.appointment_count = appointment_count
 
-    def update_next_appointments(self, count_next_appt):
+    def update_appointment_schedules(self, count_next_appt):
         self.appointment_schedules=count_next_appt
 
 

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -8,6 +8,9 @@ import datetime as dt
 import pytz
 import requests
 
+import time
+from datetime import date, timedelta, datetime
+
 from pathlib import Path
 from unidecode import unidecode
 
@@ -208,3 +211,9 @@ def get_last_scans(centres):
             centre.last_scan_with_availabilities = dt.datetime.now(tz=pytz.timezone('Europe/Paris')).isoformat()
 
     return liste_centres
+
+def date_next_n_days(day,n):
+    day=time.strptime(day,'%Y-%m-%d')
+    newdate=date(day.tm_year,day.tm_mon,day.tm_mday)+timedelta(n)
+    newdate=newdate.strftime('%Y-%m-%d')
+    return newdate


### PR DESCRIPTION
Implémentation de la #265 

Principe : une array COUNT_BEFORE précise dans doctolib.py les intervalles sur lesquelles on cherche les dispos. ([1,7] pour doctolib)
Au moment de scraper chaque URL, on récupère la date daydate+n for n in COUNT_BEFORE, et on récupère le nombre de rendez vous pour lesquels date<daydate+n

On stocke dans une array sous la forme {"1_days" : value, "7_days" : value, ...}

Dans ScraperRequest (scraper_request.py) et dans CenterInfo (center_info.py), on renomme cette array appointment_schedules

Ainsi, appointment_schedules ne contient que les jours configurés pour chaque plateforme : pour le moment days_1 et days_7 pour doctolib, et appointment_schedules est vide {} pour les autres plateformes. (pour différencier pas de récupération de la valeur 0)