### PR TITLE
Définition d'un internal_id unique et corrections doctolib

### DIFF
--- a/scraper/doctolib/doctolib.py
+++ b/scraper/doctolib/doctolib.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from scraper.doctolib.doctolib_filters import is_appointment_relevant, parse_practitioner_type, is_category_relevant
 from scraper.pattern.center_info import get_vaccine_name
 from scraper.pattern.scraper_request import ScraperRequest
+from scraper.pattern.scraper_result import INTERVAL_SPLIT_DAYS
 from scraper.error import BlockedByDoctolibError
 from scraper.profiler import Profiling
 from utils.vmd_utils import append_date_days
@@ -39,9 +40,6 @@ if os.getenv('WITH_TOR', 'no') == 'yes':
     DEFAULT_CLIENT = session  # type: ignore
 else:
     DEFAULT_CLIENT = httpx.Client()
-
-# Attention à ne pas mettre de valeur supérieure à DOCTOLIB_SLOT_LIMIT*(DOCTOLIB_ITERATIONS+1)
-INTERVAL_SPLIT_DAYS = [1, 7, 28, 49]
 
 # Vérifie qu'aucun des intervalles de calcul de dépasse l'intervalle globale de recherche des dispos 
 if not all(i <= (DOCTOLIB_SLOT_LIMIT * (DOCTOLIB_ITERATIONS + 1)) for i in INTERVAL_SPLIT_DAYS):
@@ -199,7 +197,7 @@ class DoctolibSlots:
         pid = int(pid[0])
         places = rdata.get("places", {})
         for place in places:
-            practice_id = int(re.findall(r"\d+", place.get("id", None))[0])
+            practice_id = int(re.findall(r"\d+", place.get("id", ""))[0])
             if pid == practice_id:
                 return True
         return False

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -61,7 +61,7 @@ def get_departements():
 
     # Guyane uses Maiia and does not have doctolib pages
     NOT_INCLUDED_DEPARTEMENTS = ["Guyane"]
-    with open("data/input/departements-france.csv", newline="\n") as csvfile:
+    with open("data/input/departements-france.csv", encoding="utf8", newline="\n") as csvfile:
         reader = csv.DictReader(csvfile)
         departements = [str(row["nom_departement"]) for row in reader]
         [departements.remove(ndep) for ndep in NOT_INCLUDED_DEPARTEMENTS]
@@ -123,7 +123,7 @@ def center_from_doctor_dict(doctor_dict) -> dict:
     nom = doctor_dict['name_with_title']
     sub_addresse = doctor_dict["address"]
     ville = doctor_dict["city"]
-    code_postal = doctor_dict["zipcode"]
+    code_postal = doctor_dict["zipcode"].replace(" ","").strip()
     addresse = f"{sub_addresse}, {code_postal} {ville}"
     if doctor_dict.get('place_id'):
         url_path = f"{doctor_dict['link']}?pid={str(doctor_dict['place_id'])}"
@@ -177,7 +177,7 @@ def get_dict_infos_center_page(url_path: str) -> dict:
         infos_page['long_coor1'] = place.get('longitude')
         infos_page['lat_coor1'] = place.get('latitude')
         infos_page["com_insee"] = departementUtils.cp_to_insee(
-            place["zipcode"])
+            place["zipcode"].replace(" ","").strip())
 
         # Parse landline number
         if place.get('landline_number'):

--- a/scraper/maiia/maiia.py
+++ b/scraper/maiia/maiia.py
@@ -141,7 +141,7 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT) 
 
     for reason in reasons:
         request.add_vaccine_type(get_vaccine_name(reason['name']))
-    request.update_internal_id(center_id)
+    request.update_internal_id(f"maiia{center_id}")
     request.update_appointment_count(slots_count)
     request.update_appointment_schedules(appointment_schedules)
     return first_availability.isoformat()

--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -76,8 +76,7 @@ def campagne_to_centre(pharmacy: dict, campagne: dict) -> dict:
     centre['phone_number'] = pharmacy.get('telephone', '')
     centre['rdv_site_web'] = campagne.get('url')
     centre['com_insee'] = insee
-    centre['gid'] = campagne.get('url').encode('utf8').hex()[40:][:8]
-    centre['internal_id'] = campagne.get('url').encode('utf8').hex()[40:][:8]
+    centre['gid'] = campagne.get('url').encode('utf8').hex()[52:][:23]
     return centre
 
 
@@ -178,7 +177,6 @@ def fetch_slots(
     first_availability, slot_count = parse_slots(day_slots)
     request.update_appointment_count(slot_count)
     request.update_practitioner_type(DRUG_STORE)
-    request.update_internal_id(url.encode('utf8').hex()[40:][:8])
     pharmacy, campagne = get_pharmacy_and_campagne(
         id_campagne, id_type, opendata_file)
     request.add_vaccine_type(get_vaccine_name(campagne['nom']))

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -120,6 +120,9 @@ def cherche_prochain_rdv_dans_centre(centre: dict) -> CenterInfo:
 
     if result is not None and result.request.url is not None:
         center_data.url = result.request.url.lower()
+        if result.request.internal_id is None:
+            center_data.internal_id = f'{result.platform.lower()}{centre.get("gid", "")}'
+
 
     if 'type' in centre:
         center_data.type = centre['type']

--- a/tests/fixtures/doctolib/basic-booking.json
+++ b/tests/fixtures/doctolib/basic-booking.json
@@ -20,6 +20,7 @@
     ],
     "places": [
       {
+        "id": "practice-165752",
         "practice_ids": [
           165752
         ]

--- a/tests/fixtures/doctolib/category-booking.json
+++ b/tests/fixtures/doctolib/category-booking.json
@@ -26,6 +26,7 @@
     ],
     "places": [
       {
+        "id": "practice-165752",
         "practice_ids": [
           165752
         ]

--- a/tests/fixtures/doctolib/next-slot-booking.json
+++ b/tests/fixtures/doctolib/next-slot-booking.json
@@ -26,6 +26,7 @@
     ],
     "places": [
       {
+        "id": "practice-165752",
         "practice_ids": [
           165752
         ]

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -47,7 +47,7 @@ def test_blocked_by_doctolib_par_centre():
             "limit": str(DOCTOLIB_SLOT_LIMIT),
         }
         path = Path("tests", "fixtures", "doctolib", "basic-availabilities.json")
-        return httpx.Response(200, json=json.loads(path.read_text()))
+        return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
     client = httpx.Client(transport=httpx.MockTransport(app))
     slots = DoctolibSlots(client=client, cooldown_interval=0)
@@ -72,7 +72,7 @@ def test_blocked_by_doctolib_par_availabilities():
 
         if request.url.path == "/booking/centre1.json":
             path = Path("tests", "fixtures", "doctolib", "basic-booking.json")
-            return httpx.Response(200, json=json.loads(path.read_text()))
+            return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
         return httpx.Response(403, text="Anti dDos")
 
@@ -99,12 +99,12 @@ def test_doctolib():
 
         if request.url.path == "/booking/centre1.json":
             path = Path("tests", "fixtures", "doctolib", "basic-booking.json")
-            return httpx.Response(200, json=json.loads(path.read_text()))
+            return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
         assert request.url.path == "/availabilities.json"
         params = dict(httpx.QueryParams(request.url.query))
         path = Path("tests", "fixtures", "doctolib", "basic-availabilities.json")
-        return httpx.Response(200, json=json.loads(path.read_text()))
+        return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
     client = httpx.Client(transport=httpx.MockTransport(app))
     slots = DoctolibSlots(client=client, cooldown_interval=0)
@@ -127,11 +127,11 @@ def test_doctolib_motive_categories():
 
         if request.url.path == "/booking/centre1.json":
             path = Path("tests", "fixtures", "doctolib", "category-booking.json")
-            return httpx.Response(200, json=json.loads(path.read_text()))
+            return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
         assert request.url.path == "/availabilities.json"
         path = Path("tests", "fixtures", "doctolib", "category-availabilities.json")
-        return httpx.Response(200, json=json.loads(path.read_text()))
+        return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
     client = httpx.Client(transport=httpx.MockTransport(app))
     slots = DoctolibSlots(client=client, cooldown_interval=0)
@@ -154,11 +154,11 @@ def test_doctolib_next_slot():
 
         if request.url.path == "/booking/centre1.json":
             path = Path("tests", "fixtures", "doctolib", "next-slot-booking.json")
-            return httpx.Response(200, json=json.loads(path.read_text()))
+            return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
         assert request.url.path == "/availabilities.json"
         path = Path("tests", "fixtures", "doctolib", "next-slot-availabilities.json")
-        return httpx.Response(200, json=json.loads(path.read_text()))
+        return httpx.Response(200, json=json.loads(path.read_text(encoding='utf-8')))
 
     client = httpx.Client(transport=httpx.MockTransport(app))
     slots = DoctolibSlots(client=client, cooldown_interval=0)

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -90,6 +90,7 @@ class departementUtils:
                 >>> to_departement_number('97701')  # Saint-Barthélémy
                 '971'
                 """
+        insee_code=insee_code.strip()
         if len(insee_code) == 4:
             # Quand le CSV des centres de vaccinations est édité avec un tableur comme Excel,
             # il est possible que le 1er zéro soit retiré si la colonne est interprétée comme
@@ -135,7 +136,12 @@ class departementUtils:
 
 
 def format_cp(cp: str) -> str:
-    formatted_cp = str(cp).strip().split()[0]
+    # Permet le cas du CP sous form 75 005 au lieu de 75005
+    if len(str(cp).strip().split()[0]) < 4:
+        formatted_cp = str(cp).strip().split()[0] + str(cp).strip().split()[1]
+    else:
+        formatted_cp = str(cp).strip().split()[0]
+        
     if len(formatted_cp) == 4:
         return f"0{formatted_cp}"
     return formatted_cp


### PR DESCRIPTION
Bonjour, implantation de la #287.
L'id est de la forme `f"{plateforme}{internal_id}` pour vérifier son unicité.

Il n'est en principe pas nul non plus, j'ai fait le teste et vérifié l'unicité.

Au passage, j'ai corrigé la #170 et modifié quelques fonctions se rapportant aux codes postaux pour supprimer à tous les niveaux un éventuel espace (75 005 au lieu de 75005 par exemple)