### PR TITLE
[Keldoc] Réactivation

### DIFF
--- a/scraper/keldoc/keldoc.py
+++ b/scraper/keldoc/keldoc.py
@@ -9,7 +9,9 @@ from scraper.keldoc.keldoc_filters import get_relevant_vaccine_specialties_id, f
 from scraper.pattern.scraper_request import ScraperRequest
 from scraper.profiler import Profiling
 
-timeout = httpx.Timeout(10.0, connect=10.0)
+timeout = httpx.Timeout(25.0, connect=25.0)
+# change KELDOC_KILL_SWITCH to True to bypass Keldoc scraping
+KELDOC_KILL_SWITCH = False
 KELDOC_HEADERS = {
     'User-Agent': os.environ.get('KELDOC_API_KEY', ''),
 }
@@ -21,6 +23,8 @@ def fetch_slots(request: ScraperRequest):
     if 'www.keldoc.com' in request.url:
         logger.debug(f'Fixing wrong hostname in request: {request.url}')
         request.url = request.url.replace('www.keldoc.com', 'vaccination-covid.keldoc.com')
+    if KELDOC_KILL_SWITCH:
+        return None
     center = KeldocCenter(request, client=session)
     # Unable to parse center resources (id, location)?
     if not center.parse_resource():

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -306,7 +306,7 @@ def gouv_centre_iterator(outpath_format='data/output/{}.json'):
 
 
 def should_use_opendata_csv(rdv_site_web: str) -> bool:
-    plateformes_hors_csv = ['doctolib', 'maiia', 'keldoc']
+    plateformes_hors_csv = ['doctolib', 'maiia']
     
     if any(p in rdv_site_web for p in plateformes_hors_csv):
         return False


### PR DESCRIPTION
- Ajout d'un kill switch dans keldoc.py
- On repasse à une seule requête pour tous les agendas d'une motive, la requête agenda par agenda étant trop lente
- Fix #308 