### PR TITLE
[Doctolib] Correction compte nombre de rendez vous et appointment_schedules + ajout 2_days

### DIFF
--- a/scraper/pattern/scraper_result.py
+++ b/scraper/pattern/scraper_result.py
@@ -10,7 +10,7 @@ VACCINATION_CENTER = 'vaccination-center'
 DRUG_STORE = 'drugstore'
 
 # Schedules array for appointments by interval
-INTERVAL_SPLIT_DAYS = [1, 7, 28, 49]
+INTERVAL_SPLIT_DAYS = [1, 2, 7, 28, 49]
 
 class ScraperResult:
     def __init__(self, request: ScraperRequest, platform, next_availability):

--- a/tests/test_keldoc.py
+++ b/tests/test_keldoc.py
@@ -93,7 +93,7 @@ def test_keldoc_parse_center():
     date, count, appointment_schedules = test_center_1.find_first_availability("2020-04-04")
     tz = datetime.timezone(datetime.timedelta(seconds=7200))
     assert date == datetime.datetime(2021, 4, 20, 16, 55, tzinfo=tz)
-    assert appointment_schedules == {'1_days': 0, '28_days': 0, '49_days': 0, '7_days': 0}
+    assert appointment_schedules == {'1_days': 0, '2_days': 0, '28_days': 0, '49_days': 0, '7_days': 0}
 
 
 def test_keldoc_missing_params():

--- a/tests/test_maiia.py
+++ b/tests/test_maiia.py
@@ -74,7 +74,7 @@ def test_get_first_availability():
         '2021-04-29', 
         reasons, 
         client=client)
-    assert appointment_schedules == {'1_days': 0, '28_days': 6570, '49_days': 7980, '7_days': 0}
+    assert appointment_schedules == {'1_days': 0, '2_days': 0, '28_days': 6570, '49_days': 7980, '7_days': 0}
     assert slots_count == 7980
     assert first_availability.isoformat() == '2021-05-13T13:40:00+00:00'
 


### PR DESCRIPTION
J'ai remarqué des erreurs sur les calculs des appointment_schedules, qui sont maintenant corrigées avec quelques petits.

1_days contient désormais uniquement les rdvs du jour courant jusqu'à 23h59, et 2_days les rdvs du jour courant et du lendemain jusqu'à 23h59 !

J'ai du faire quelques changements sur l'iterator pour aller chercher jusqu'à 49 jours :)