### PR TITLE
Faire vraiment l'import export en parallèle.

### DIFF
--- a/scraper/doctolib/doctolib.py
+++ b/scraper/doctolib/doctolib.py
@@ -29,7 +29,16 @@ DOCTOLIB_HEADERS = {
     "User-Agent": os.environ.get("DOCTOLIB_API_KEY", ""),
 }
 
-DEFAULT_CLIENT = httpx.Client()
+if os.getenv('WITH_TOR', 'no') == 'yes':
+    session = requests.Session()
+    session.proxies = {  # type: ignore
+        'http': 'socks5://127.0.0.1:9050',
+        'https': 'socks5://127.0.0.1:9050',
+    }
+    DEFAULT_CLIENT = session  # type: ignore
+else:
+    DEFAULT_CLIENT = httpx.Client()
+
 logger = logging.getLogger("scraper")
 
 # Vérifie qu'aucun des intervalles de calcul de dépasse l'intervalle globale de recherche des dispos

--- a/scraper/export/export_merge.py
+++ b/scraper/export/export_merge.py
@@ -42,8 +42,9 @@ def export_data(centres_cherchés: Iterator[CenterInfo], outpath_format="data/ou
     is_blocked_center = lambda center: (is_reserved_center(center) or is_in_blocklist(center, blocklist))
 
     for centre in centres_cherchés:
-        if is_blocked_center(centre) and centre.has_available_appointments():
-            logger.warn(f"{centre.nom} {centre.internal_id} has available appointments but is blocked")
+        if is_blocked_center(centre):
+            if centre.has_available_appointments():
+                logger.warn(f"{centre.nom} {centre.internal_id} has available appointments but is blocked")
             continue
 
         compte_centres += 1

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,5 +1,4 @@
 import os
-import os
 import traceback
 from collections import deque
 from multiprocessing import Pool
@@ -52,8 +51,7 @@ def scrape(platforms=None) -> None:  # pragma: no cover
     profiler = Profiling()
     with profiler, Pool(POOL_SIZE, **profiler.pool_args()) as pool:
         centre_iterator_proportion = (c for c in centre_iterator(platforms=platforms) if random() < PARTIAL_SCRAPE)
-        centres_cherchés = pool.imap_unordered(cherche_prochain_rdv_dans_centre, centre_iterator_proportion,
-                                               1)
+        centres_cherchés = pool.imap_unordered(cherche_prochain_rdv_dans_centre, centre_iterator_proportion, 1)
 
         centres_cherchés = get_last_scans(centres_cherchés)
         if platforms:

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -226,7 +226,6 @@ def test_export_data(tmp_path):
         },
     ]
 
-
 def test_export_reserved_centers(tmp_path):
     centres_cherchés_dict = [
         {


### PR DESCRIPTION
**Description**

J'ai fait en sorte d'éviter de consommer l'itérateur des centres recherchés pour en faire un immense tableau en mémoire. Comme ça l'import et l'export se font en simultané et (normalement) de manière un peu efficace en mémoire.