### PR TITLE
[DOCTOLIB] Fix #390 , retrait des adresses Doctolib partners

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -133,11 +133,9 @@ def center_from_doctor_dict(doctor_dict) -> dict:
         url_path = f"{doctor_dict['link']}?pid={str(doctor_dict['place_id'])}"
     else:
         url_path = doctor_dict["link"]
+
     _type = center_type(url_path, nom)
-    if _type == VACCINATION_CENTER:
-        rdv_site_web = f"https://partners.doctolib.fr{url_path}"
-    else:
-        rdv_site_web = f"https://www.doctolib.fr{url_path}"
+    rdv_site_web = f"https://www.doctolib.fr{url_path}"
 
     dict_infos_center_page = get_dict_infos_center_page(url_path)
     longitude, latitude = get_coordinates(doctor_dict)


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit être en majuscule et concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [x] Fix #issue
- [ ] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Remplace les urls de type partners.doctolib.fr par www.doctolib.fr