### PR TITLE
Fix scraper --url, accept multiple --url

### DIFF
--- a/scraper/main.py
+++ b/scraper/main.py
@@ -8,7 +8,7 @@ from scraper.scraper import scrape, scrape_debug
 def main():  # pragma: no cover
     parser = argparse.ArgumentParser()
     parser.add_argument("--platform", "-p", help="scrape platform. (eg: doctolib,keldoc or all)")
-    parser.add_argument("--url", "-u", help="scrape one url")
+    parser.add_argument("--url", "-u", action="append", help="scrape one url, can be repeated")
     parser.add_argument("--merge", "-m", help="merge platform results", action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION

<!-- 
En bref :
* Le titre du PR doit être en majuscule et concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [ ] Fix #issue
- [ ] J'ai ajouté des tests (si nécessaire)
- [ ] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
`scrape_debug()` takes a list of url, and was given one url from `argparse`.
This commit adds support for multiple `--url` cli arguments, fixing the type bug at the same time.
