### PR TITLE
Ajout de fichier de config pour black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+target-version = ['py38']
+include = '\.pyi?$'


### PR DESCRIPTION
**Description**

L'objectif de cette PR est d'ajouter un fichier de configuration pour `black`, en particulier pour configurer la taille de ligne qui n'est pas celle par défaut et qui oblige actuellement à lancer `black` avec des options.