### PR TITLE
[Keldoc] optimise le nombre de requêtes quand la date est lointaine

### DIFF
--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from math import floor
 from urllib.parse import urlsplit, parse_qs
 from datetime import datetime, timedelta
 from dateutil.parser import isoparse
@@ -144,7 +145,8 @@ class KeldocCenter:
 
         end_date = (start_date + timedelta(days=KELDOC_DAYS_PER_PAGE)).strftime("%Y-%m-%d")
         logger.debug(
-            f"get_timetables -> start_date: {start_date} end_date: {end_date} motive: {motive_id} agenda: {agenda_ids}"
+            f"get_timetables -> start_date: {start_date} end_date: {end_date} "
+            f"motive: {motive_id} agenda: {agenda_ids} (page: {page})"
         )
         calendar_params = {
             "from": start_date.strftime("%Y-%m-%d"),
@@ -177,8 +179,24 @@ class KeldocCenter:
             return timetable
 
         # Get the first date only
-        if "date" in current_timetable and "date" not in timetable:
-            timetable["date"] = current_timetable.get("date")
+        if "date" in current_timetable:
+            if not "date" not in timetable:
+                timetable["date"] = current_timetable.get("date")
+            """
+            Optimize query count by jumping directly to the first availability date by using ’date’ key
+            Checks for the presence of the ’availabilities’ attribute, even if it's not supposed to be set
+            """
+            if "availabilities" not in current_timetable:
+                next_expected_date = start_date + timedelta(days=KELDOC_DAYS_PER_PAGE)
+                next_fetch_date = isoparse(current_timetable["date"])
+                diff = next_fetch_date.replace(tzinfo=None) - next_expected_date.replace(tzinfo=None)
+                return self.get_timetables(
+                    next_fetch_date,
+                    motive_id,
+                    agenda_ids,
+                    1 + floor(diff.days / KELDOC_DAYS_PER_PAGE) + page,
+                    timetable,
+                )
 
         # Insert availabilities
         if "availabilities" in current_timetable:
@@ -193,7 +211,7 @@ class KeldocCenter:
         if page >= KELDOC_SLOT_PAGES:
             return timetable
         return self.get_timetables(
-            start_date + timedelta(days=KELDOC_DAYS_PER_PAGE), motive_id, agenda_ids, page=1 + page, timetable=timetable
+            start_date + timedelta(days=KELDOC_DAYS_PER_PAGE), motive_id, agenda_ids, 1 + page, timetable
         )
 
     def count_appointements(self, appointments: list, start_date: str, end_date: str) -> int:


### PR DESCRIPTION
**Checklist**

- [ ] Fix #issue
- [ ] J'ai ajouté des tests (si nécessaire)
- [X] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

La timetable sur mon dernier push ne permettait pas d'aller directement à la prochaine date indiquée où il y a un créneau disponible, et pouvait donc continuer de vérifier une plage de dates où il n'y avait pas de créneau.

Pour être plus intelligent au niveau du scrap, au lieu d'aller chercher des plages de date où l'on sait qu'il n'y a pas de créneaux, on jump directement à l'endroit où il y a la première dispo dans la timetable.
