### PR TITLE
[Ordoclic] Mise à jour du filtre de recherche

### DIFF
--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -40,8 +40,10 @@ def search(client: httpx.Client = DEFAULT_CLIENT):
         "per_page": "10000",
         "in.isPublicProfile": "true",
         "in.isCovidVaccineSupported": "true",
-        "or.covidOnlineBookingAvailabilities.Vaccination Pfizer": "true",
-        "or.covidOnlineBookingAvailabilities.Vaccination AstraZeneca": "true",
+        "or.covidOnlineBookingAvailabilities.vaccineAstraZeneca1": "true",
+        "or.covidOnlineBookingAvailabilities.vaccineJanssen1": "true",
+        "or.covidOnlineBookingAvailabilities.vaccinePfizer1": "true",
+        "or.covidOnlineBookingAvailabilities.vaccineModerna1": "true",
     }
     try:
         r = client.get(base_url, params=payload)

--- a/tests/fixtures/ordoclic/search.schema
+++ b/tests/fixtures/ordoclic/search.schema
@@ -152,10 +152,25 @@
             "covidOnlineBookingAvailabilities": {
               "type": "object",
               "properties": {
-                "Vaccination AstraZeneca": {
+                "vaccineAstraZeneca1": {
                   "type": "boolean"
                 },
-                "Vaccination Pfizer": {
+                "vaccineAstraZeneca2": {
+                  "type": "boolean"
+                },
+                "vaccineJanssen1": {
+                  "type": "boolean"
+                },
+                "vaccinePfizer1": {
+                  "type": "boolean"
+                },
+                "vaccinePfizer2": {
+                  "type": "boolean"
+                },
+                "vaccineModerna1": {
+                  "type": "boolean"
+                },
+                "vaccineModerna2": {
                   "type": "boolean"
                 },
                 "antigenic": {
@@ -163,8 +178,10 @@
                 }
               },
               "required": [
-                "Vaccination AstraZeneca",
-                "Vaccination Pfizer",
+                "vaccineAstraZeneca1",
+                "vaccineJanssen1",
+                "vaccinePfizer1",
+                "vaccineModerna1",
                 "antigenic"
               ]
             }

--- a/tests/test_ordoclic.py
+++ b/tests/test_ordoclic.py
@@ -31,8 +31,10 @@ def test_search():
             "per_page": "10000",
             "in.isPublicProfile": "true",
             "in.isCovidVaccineSupported": "true",
-            "or.covidOnlineBookingAvailabilities.Vaccination AstraZeneca": "true",
-            "or.covidOnlineBookingAvailabilities.Vaccination Pfizer": "true",
+            "or.covidOnlineBookingAvailabilities.vaccineAstraZeneca1": "true",
+            "or.covidOnlineBookingAvailabilities.vaccineJanssen1": "true",
+            "or.covidOnlineBookingAvailabilities.vaccinePfizer1": "true",
+            "or.covidOnlineBookingAvailabilities.vaccineModerna1": "true",
         }
 
         path = Path("tests/fixtures/ordoclic/search.json")
@@ -197,8 +199,10 @@ def test_center_iterator():
             "per_page": "10000",
             "in.isPublicProfile": "true",
             "in.isCovidVaccineSupported": "true",
-            "or.covidOnlineBookingAvailabilities.Vaccination AstraZeneca": "true",
-            "or.covidOnlineBookingAvailabilities.Vaccination Pfizer": "true",
+            "or.covidOnlineBookingAvailabilities.vaccineAstraZeneca1": "true",
+            "or.covidOnlineBookingAvailabilities.vaccineJanssen1": "true",
+            "or.covidOnlineBookingAvailabilities.vaccinePfizer1": "true",
+            "or.covidOnlineBookingAvailabilities.vaccineModerna1": "true",
         }
 
         path = Path("tests/fixtures/ordoclic/search.json")

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -133,6 +133,7 @@ class departementUtils:
 
 def format_cp(cp: str) -> str:
     # Permet le cas du CP sous form 75 005 au lieu de 75005
+    formatted_cp = cp
     if len(re.findall(r"\d+", cp)) > 0:
         formatted_cp = re.findall(r"\d+", cp)[0]
     else:


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [x] Fix #413 
- [x] J'ai ajouté des tests (si nécessaire)
- [ ] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Suite à une mise à jour de l'API Ordoclic, les paramètres de la recherche des centres ont changé et plus aucun centre Ordoclic ne remonte de l'iterator
