### PR TITLE
[Keldoc] Réduction du scrape à 10 jours

### DIFF
--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -17,7 +17,7 @@ KELDOC_HEADERS = {
     "User-Agent": os.environ.get("KELDOC_API_KEY", ""),
 }
 # 16 days is enough for now, due to recent issues with Keldoc API
-KELDOC_SLOT_PAGES = 4
+KELDOC_SLOT_PAGES = 2
 KELDOC_DAYS_PER_PAGE = 4
 DEFAULT_CLIENT = httpx.Client(timeout=timeout, headers=KELDOC_HEADERS)
 logger = logging.getLogger("scraper")


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [ ] Fix #issue
- [ ] J'ai ajouté des tests (si nécessaire)
- [ ] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

On a beaucoup de timeout, je propose de limiter la recherche d'agendas à 2 pages soit 10 jours au moins pour aujourd'hjui qui va être une journée très chargée
