### PR TITLE
#384 Export spécifique aux collectivités d'outre-mer

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -78,6 +78,20 @@ def test_export_data(tmp_path):
             "appointment_count": 1,
             "internal_id": None,
         },
+        {
+            # Not technically a department, should be in om.json
+            "departement": "975",
+            "nom": "Exemple Saint Pierre et Miquelon",
+            "url": "https://example.com/st-pierre-miquelon",
+            "plateforme": "Doctolib",
+            "prochain_rdv": "2021-05-10T00:00:00",
+            "location": None,
+            "metadata": None,
+            "type": None,
+            "appointment_by_phone_only": False,
+            "appointment_count": 1,
+            "internal_id": None,
+        },
     ]
     centres_cherchés = [dict_to_center_info(center) for center in centres_cherchés_dict]
 
@@ -205,6 +219,33 @@ def test_export_data(tmp_path):
         "last_updated": "2021-04-04T00:00:00",
     }
 
+    # outre-mer file should contain St Pierre et Miquelon data
+    content = json.loads((out_dir / "om.json").read_text())
+    assert content == {
+        "version": 1,
+        "centres_disponibles": [
+            {
+                "departement": "om",
+                "nom": "Exemple Saint Pierre et Miquelon",
+                "url": "https://example.com/st-pierre-miquelon",
+                "plateforme": "Doctolib",
+                "prochain_rdv": "2021-05-10T00:00:00",
+                "location": None,
+                "metadata": None,
+                "type": None,
+                "appointment_by_phone_only": False,
+                "appointment_count": 1,
+                "internal_id": None,
+                "vaccine_type": None,
+                "erreur": None,
+                "last_scan_with_availabilities": None,
+            },
+        ],
+        "centres_indisponibles": [],
+        "last_scrap": [],
+        "last_updated": "2021-04-04T00:00:00",
+    }
+
     # On test l'export vers le format inscrit sur la plateforme data.gouv.fr
     content = json.loads((out_dir / "centres_open_data.json").read_text())
     assert content == [
@@ -226,6 +267,12 @@ def test_export_data(tmp_path):
             "nom": "Médiathèque Jacques GAUTIER",
             "url": "https://example.com/mediatheque-jacques-gautier",
             "plateforme": "Maiia",
+        },
+        {
+            "departement": "om",
+            "nom": "Exemple Saint Pierre et Miquelon",
+            "plateforme": "Doctolib",
+            "url": "https://example.com/st-pierre-miquelon",
         },
     ]
 


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [ ] Should fix https://github.com/CovidTrackerFr/vitemadose/issues/384 (à vérifier avec le front)
- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Les centres ayant un code département égal à  975, 977, 978 ou 98 sont exportés dans un fichier om.json comme suggéré ici 
https://github.com/CovidTrackerFr/vitemadose/issues/384
<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
