### PR TITLE
Add a script to count appointments per vaccine type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ scrape: ## runs the full scraping experience
 stats: ## Run the statistic scripts
 	venv/bin/python -m stats_generation.stats_available_centers
 	venv/bin/python -m stats_generation.chronodoses
+	venv/bin/python -m stats_generation.chronodoses_by_vaccine
 
 doctoscrap: ## Scrap all doctolib centers, output : data/output/doctolib-centers.json
 	venv/bin/python -m scraper.doctolib.doctolib_center_scrap

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ scrape: ## runs the full scraping experience
 stats: ## Run the statistic scripts
 	venv/bin/python -m stats_generation.stats_available_centers
 	venv/bin/python -m stats_generation.chronodoses
-	venv/bin/python -m stats_generation.chronodoses_by_vaccine
+	venv/bin/python -m stats_generation.by_vaccine
 
 doctoscrap: ## Scrap all doctolib centers, output : data/output/doctolib-centers.json
 	venv/bin/python -m scraper.doctolib.doctolib_center_scrap

--- a/config.json
+++ b/config.json
@@ -20,6 +20,7 @@
       "chronodoses": "data/output/stats_chronodoses.json",
       "by_date": "stats_by_date.json",
       "by_date_dep": "stats_by_date_dep.json",
+      "by_vaccine_type": "data/output/stats_by_vaccine.json",
       "center_types": "stats_center_types.json",
       "global": "stats.json"
     },

--- a/stats_generation/by_vaccine.py
+++ b/stats_generation/by_vaccine.py
@@ -1,0 +1,82 @@
+"""Sums available appointments per vaccine type.
+
+Note: There are ~10% of centers that report multiple vaccine types.
+For those, the individual breakdown is not clear, so they are left out at the moment.
+
+Issue: https://github.com/CovidTrackerFr/vitemadose/issues/266
+
+Usage:
+
+```shell
+python3 -m stats_generation.chronodoses_by_vaccine \
+    --input="some/file.json" # Optional (should follow the same structure as data/output/info_centres.json.)\
+    --output="put/it/here.json" # Optional
+```
+
+"""
+import argparse
+import json
+import sys
+from functools import reduce
+from pathlib import Path
+from typing import Iterator, List, Tuple
+
+from utils.vmd_config import get_conf_outputs, get_conf_outstats
+
+_default_input = Path(get_conf_outputs().get("last_scans"))
+_default_output = Path(get_conf_outstats().get("by_vaccine_type"))
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input",
+        default=_default_input,
+        type=Path,
+        help="File with the statistics per department. Should follow the same structure as info_centres.json.",
+    )
+    parser.add_argument(
+        "--output",
+        default=_default_output,
+        type=Path,
+        help="Where to put the resulting statistics.",
+    )
+    return parser.parse_args(args)
+
+
+def merge(data: dict, new: tuple) -> dict:
+    vaccine_type, appointments = new
+    if vaccine_type in data:
+        data[vaccine_type] += appointments
+    else:
+        data[vaccine_type] = appointments
+    return data
+
+
+def flatten_vaccine_types_schedules(data: dict) -> Iterator[Tuple[str, int]]:
+    return (
+        (center["vaccine_type"][0], schedule["total"])
+        for department in data.values()
+        for center in department["centres_disponibles"]
+        for schedule in center["appointment_schedules"]
+        # Some centers report multiple vaccine types and it’s not clear how many are available for each
+        # schedulable appointment. So, for the moment, they are left out.
+        if len(center["vaccine_type"] or []) == 1
+    )
+
+
+def main(argv):
+    args = parse_args(argv[1:])
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    available_center_schedules = flatten_vaccine_types_schedules(data)
+    by_vaccine_type = reduce(merge, available_center_schedules, {})
+
+    with open(args.output, "w") as f:
+        json.dump(by_vaccine_type, f)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/tests/stats_generation/test_by_vaccine.py
+++ b/tests/stats_generation/test_by_vaccine.py
@@ -1,0 +1,44 @@
+from functools import reduce
+from stats_generation import by_vaccine
+
+
+def test_merge():
+    data = {}
+    by_vaccine.merge(data, ("Astra", 10))
+    assert data == {"Astra": 10}
+
+    by_vaccine.merge(data, ("Astra", 10))
+    assert data == {"Astra": 20}
+
+    by_vaccine.merge(data, ("Pfizer", 100))
+    assert data == {"Astra": 20, "Pfizer": 100}
+
+
+def test_flatten_vaccine_types():
+    data = {
+        "01": {
+            "centres_disponibles": [
+                # Dropped because it lists multiple vaccine types.
+                {"appointment_schedules": [{"total": 10}], "vaccine_type": ["Pfizer", "Astra"]},
+                {"appointment_schedules": [{"total": 10}], "vaccine_type": ["Pfizer"]},
+            ],
+            "centres_indisponibles": [
+                {"vaccine_type": ["Pfizer"]},
+                {"vaccine_type": ["Astra"]},
+            ],
+        },
+        "02": {
+            "centres_disponibles": [
+                {"appointment_schedules": [{"total": 10}], "vaccine_type": ["Pfizer"]},
+                {"appointment_schedules": [{"total": 100}], "vaccine_type": ["Astra"]},
+            ],
+            "centres_indisponibles": [],
+        },
+        "03": {
+            "centres_disponibles": [],
+            "centres_indisponibles": [],
+        },
+    }
+    flattened = list(by_vaccine.flatten_vaccine_types_schedules(data))
+    assert flattened == [("Pfizer", 10), ("Pfizer", 10), ("Astra", 100)]
+    assert reduce(by_vaccine.merge, flattened, {}) == {"Astra": 100, "Pfizer": 20}


### PR DESCRIPTION
**Checklist**

- [x] Fix #266
- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Ajoute un script qui compte les rendez-vous disponibles par type de vaccin.

Note : Certains centres (~10%) listent plusieurs types de vaccins. Dans ces cas là, la répartition par vaccin n’est pas claire, alors je les ai laissés de côté pour l’instant.

Si quelqu’un sait faire autrement, qu’il se manifeste :D