### PR TITLE
Empêche les pushes de mauvais scraps de centres doctolib

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -174,7 +174,7 @@ def get_dict_infos_center_page(url_path: str) -> dict:
         data.raise_for_status()
         output = data.json().get("data", {})
     except:
-        logger.error(f"> Could not retrieve data from {internal_api_url}")
+        logger.warn(f"> Could not retrieve data from {internal_api_url}")
         return liste_infos_page
 
     # Parse place
@@ -269,7 +269,7 @@ if __name__ == "__main__":  # pragma: no cover
         logger.info(f"Found {len(centers)} centers on Doctolib")
         if len(centers) < 10000:
             # for reference, on 13-05, there were 12k centers
-            logger.warn(f"[NOT SAVING RESULTS]{len(centers)} does not seem like enough Doctolib centers")
+            logger.error(f"[NOT SAVING RESULTS]{len(centers)} does not seem like enough Doctolib centers")
         else:
             logger.info(f"> Writing them on {path_out}")
             with open(path_out, "w") as f:

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -174,7 +174,7 @@ def get_dict_infos_center_page(url_path: str) -> dict:
         data.raise_for_status()
         output = data.json().get("data", {})
     except:
-        logger.warning(f"> Could not retrieve data from {internal_api_url}")
+        logger.error(f"> Could not retrieve data from {internal_api_url}")
         return liste_infos_page
 
     # Parse place

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -267,9 +267,13 @@ if __name__ == "__main__":  # pragma: no cover
         centers = parse_doctolib_centers()
         path_out = SCRAPER_CONF.get("result_path")
         logger.info(f"Found {len(centers)} centers on Doctolib")
-        logger.info(f"> Writing them on {path_out}")
-        with open(path_out, "w") as f:
-            f.write(json.dumps(centers, indent=2))
+        if len(centers) < 10000:
+            # for reference, on 13-05, there were 12k centers
+            logger.warn(f"[NOT SAVING RESULTS]{len(centers)} does not seem like enough Doctolib centers")
+        else:
+            logger.info(f"> Writing them on {path_out}")
+            with open(path_out, "w") as f:
+                f.write(json.dumps(centers, indent=2))
     else:
         logger.error(f"Doctolib scraper is disabled in configuration file.")
         exit(1)


### PR DESCRIPTION
**Checklist**

- [x] Fix mauvais scraps de centres suite à un bloquage de Doctolib qui ne retourne pas assez de centres
- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

[On a fait un scrap de centres qui est passé avec seulement 4 départements avant de se faire 403 par Doctolib](https://github.com/CovidTrackerFr/vitemadose/actions/runs/840112430). Du coup, le site n'a pas eu tous les centres pendant 30+ minutes et a été hot-fix par une intervention sur le code. Ce fix devrait empêcher ce problème dans le futur.