### PR TITLE
[Doctolib Scraper] Améliorer le temps de scrape des centres

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -49,19 +49,19 @@ def parse_doctolib_centers(page_limit=None) -> List[dict]:
     centers = []
     unique_center_urls = []
 
-    pool = multiprocessing.Pool(50)
-    centers = pool.map(run_departement_scrap, get_departements())
+    with multiprocessing.Pool(50) as pool:
+        centers = pool.imap_unordered(run_departement_scrap, get_departements())
 
-    centers = list(filter(is_vaccination_center, centers))  # Filter vaccination centers
-    centers = list(map(center_reducer, centers))  # Remove fields irrelevant to the front
+        centers = list(filter(is_vaccination_center, centers))  # Filter vaccination centers
+        centers = list(map(center_reducer, centers))  # Remove fields irrelevant to the front
 
-    for item in list(centers):
-        if item.get("rdv_site_web") in unique_center_urls:
-            centers.remove(item)
-            continue
-        unique_center_urls.append(item.get("rdv_site_web"))
+        for item in list(centers):
+            if item.get("rdv_site_web") in unique_center_urls:
+                centers.remove(item)
+                continue
+            unique_center_urls.append(item.get("rdv_site_web"))
 
-    return centers
+        return centers
 
 
 def get_departements():

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -302,7 +302,7 @@ if __name__ == "__main__":  # pragma: no cover
         else:
             logger.info(f"> Writing them on {path_out}")
             with open(path_out, "w") as f:
-                f.write(json.dumps(centers, indent=2))
+                f.write(json.dumps(centers))
     else:
         logger.error(f"Doctolib scraper is disabled in configuration file.")
         exit(1)

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -50,8 +50,11 @@ def parse_doctolib_centers(page_limit=None) -> List[dict]:
     unique_center_urls = []
 
     with multiprocessing.Pool(50) as pool:
-        centers = pool.imap_unordered(run_departement_scrap, get_departements())
+        center_lists = pool.imap_unordered(run_departement_scrap, get_departements())
+        centers = []
 
+        for center_list in center_lists:
+            centers.extend(center_list)
         centers = list(filter(is_vaccination_center, centers))  # Filter vaccination centers
         centers = list(map(center_reducer, centers))  # Remove fields irrelevant to the front
 

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -49,7 +49,7 @@ def parse_doctolib_centers(page_limit=None) -> List[dict]:
     centers = []
     unique_center_urls = []
 
-    pool = multiprocessing.Pool()
+    pool = multiprocessing.Pool(50)
     centers = pool.map(run_departement_scrap, get_departements())
 
     centers = list(filter(is_vaccination_center, centers))  # Filter vaccination centers
@@ -296,7 +296,6 @@ if __name__ == "__main__":  # pragma: no cover
         if len(centers) < 2000:
             # for reference, on 13-05, there were 12k centers
             logger.error(f"[NOT SAVING RESULTS]{len(centers)} does not seem like enough Doctolib centers")
-            exit(1)
         else:
             logger.info(f"> Writing them on {path_out}")
             with open(path_out, "w") as f:


### PR DESCRIPTION
**Description**

Deuxième amélioration pour le scraper Doctolib. Avant, nous scrapions Doctolib en + de 1h30 /!\
J'ai trouvé que nous arrivions à la fin avec une liste de 12 000 centres. En fait, le système de recherche de Doctolib propose des résultats qui ne sont pas forcément dans le département, quand il ne trouve plus de lieux de vaccination à la page où l'on est, ce qui fait cause des doublons quand on scrape département par département. J'ai donc fixé ce point avant. On est descendu à 20 minutes de scrape, ce qui est déjà beaucoup plus raisonnable, et nous avons divisé notre nombre de requêtes par 4.

Cette PR, en l'occurrence, permet d'améliorer le temps de scrape des centres : avec un Pool, on passe à 3 minutes en moyenne (github action) pour scraper toute la liste des centres, ce qui est encore mieux.

**Pourquoi ?**

Il est nécessaire de passer à un temps plus court pour le scrape des centres, car nous allons retirer l'utilisation de l'endpont `booking` dans le scraper de **créneaux** et utiliser les données qui sont générées sur cet endpoint par le scraper des centres, ce qui permettra de baisser de plus d'1/3 le nombre de requêtes pour Doctolib sur le scraper de créneaux (ça fait tout de même 2500 requêtes en moins toutes les cinq minutes). Baisser le temps pour scraper les centres permettra de passer de 6 heures par scrap de centres à un temps plus inférieur (pas besoin de le faire toutes les 10 minutes non plus, évidemment), pour avoir des données booking quand même raisonnablement à jour (tester à 2h?)

