### PR TITLE
[Mapharma] filtre total_libres = 0

### DIFF
--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -11,6 +11,7 @@ from urllib.parse import parse_qs
 from bs4 import BeautifulSoup
 from pathlib import Path
 from urllib import parse
+from typing import Optional
 
 from scraper.pattern.scraper_request import ScraperRequest
 from scraper.pattern.scraper_result import DRUG_STORE
@@ -171,7 +172,7 @@ def count_appointements(slots: dict, start_date: datetime, end_date: datetime) -
 @Profiling.measure("mapharma_slot")
 def fetch_slots(
     request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT, opendata_file: str = MAPHARMA_OPEN_DATA_FILE
-) -> str:
+) -> Optional[str]:
     url = request.get_url()
     # on récupère les paramètres c (id_campagne) & l (id_type)
     params = dict(parse.parse_qsl(parse.urlsplit(url).query))

--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -178,6 +178,11 @@ def fetch_slots(
     id_campagne = int(params.get("c"))
     id_type = int(params.get("l"))
     day_slots = {}
+    # certaines campagnes ont des dispos mais 0 doses
+    # si total_libres est à 0 c'est qu'il n'y a pas de vraies dispo
+    pharmacy, campagne = get_pharmacy_and_campagne(id_campagne, id_type, opendata_file)
+    if campagne is None or campagne["total_libres"] == 0:
+        return None
     # l'api ne renvoie que 7 jours, on parse un peu plus loin dans le temps
     start_date = date.fromisoformat(request.get_start_date())
     for delta in range(0, MAPHARMA_SLOT_LIMIT, 6):
@@ -194,7 +199,6 @@ def fetch_slots(
     first_availability, slot_count = parse_slots(day_slots)
     request.update_appointment_count(slot_count)
     request.update_practitioner_type(DRUG_STORE)
-    pharmacy, campagne = get_pharmacy_and_campagne(id_campagne, id_type, opendata_file)
     request.add_vaccine_type(get_vaccine_name(campagne["nom"]))
 
     appointment_schedules = []

--- a/tests/test_mapharma.py
+++ b/tests/test_mapharma.py
@@ -48,6 +48,10 @@ def test_fetch_slots():
     first_availability = fetch_slots(request, client, opendata_file=TEST_OPEN_DATA_FILE)
     assert first_availability == "2021-04-19T17:15:00"
 
+    # test campagne["total_libres"]: 0
+    request = ScraperRequest("https://mapharma.net/88400?c=92&l=1", "2021-04-14")
+    first_availability = fetch_slots(request, client, opendata_file=TEST_OPEN_DATA_FILE)
+    assert first_availability == None
 
 def test_campaign_to_center():
     pharma = {


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [x] Fix #456 
- [x] J'ai ajouté des tests (si nécessaire)
- [ ] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Certaines campagnes mapharma ont des créneaux disponibles sur l'API mais non affichés sur leur site. Ce sont en fait des calendriers qui sont en attente de réception de vaccins et donc il ne faut pas les afficher comme disponibles
On cherche donc la campagne dans l'opendata pour vérifier total_libres. Si sa valeur est nulle on arrête le fetch_slot et on renvoie None, sinon on va parser les agendas
