### PR TITLE
Use booking input data for Doctolib rdv

### DIFF
--- a/scraper/doctolib/doctolib.py
+++ b/scraper/doctolib/doctolib.py
@@ -47,6 +47,7 @@ else:
 
 logger = logging.getLogger("scraper")
 
+
 @Profiling.measure("doctolib_slot")
 def fetch_slots(request: ScraperRequest):
     if not DOCTOLIB_ENABLED:
@@ -149,15 +150,31 @@ class DoctolibSlots:
 
             agenda_ids_q = "-".join(agenda_ids)
             practice_ids_q = "-".join(practice_ids)
-            availability = self.get_timetables(request, visit_motive_ids, visit_motive_id, agenda_ids_q,
-                                               practice_ids_q, timetable_start_date, appointment_schedules)
+            availability = self.get_timetables(
+                request,
+                visit_motive_ids,
+                visit_motive_id,
+                agenda_ids_q,
+                practice_ids_q,
+                timetable_start_date,
+                appointment_schedules,
+            )
             if availability and (not first_availability or availability < first_availability):
                 first_availability = availability
         return first_availability
 
-    def get_timetables(self, request: ScraperRequest, visit_motive_ids, visit_motive_id, agenda_ids_q: str,
-                       practice_ids_q: str, start_date: datetime, appointment_schedules: list, page: int = 1,
-                       first_availability: Optional[str] = None) -> Optional[str]:
+    def get_timetables(
+        self,
+        request: ScraperRequest,
+        visit_motive_ids,
+        visit_motive_id,
+        agenda_ids_q: str,
+        practice_ids_q: str,
+        start_date: datetime,
+        appointment_schedules: list,
+        page: int = 1,
+        first_availability: Optional[str] = None,
+    ) -> Optional[str]:
         """
         Get timetables recursively with DOCTOLIB_DAYS_PER_PAGE as the number of days to query.
         Recursively limited by DOCTOLIB_SLOT_PAGES and appends new availabilities to a ’timetable’,
@@ -182,18 +199,25 @@ class DoctolibSlots:
             return first_availability
         if next_slot:
             """
-                Optimize query count by jumping directly to the first availability date by using ’next_slot’ key
+            Optimize query count by jumping directly to the first availability date by using ’next_slot’ key
             """
             next_expected_date = start_date + timedelta(days=DOCTOLIB_DAYS_PER_PAGE)
-            next_fetch_date = datetime.strptime(next_slot, '%Y-%m-%d')
+            next_fetch_date = datetime.strptime(next_slot, "%Y-%m-%d")
             diff = next_fetch_date.replace(tzinfo=None) - next_expected_date.replace(tzinfo=None)
 
             if page > DOCTOLIB_SLOT_PAGES:
                 return first_availability
-            return self.get_timetables(request, visit_motive_ids, visit_motive_id, agenda_ids_q,
-                                       practice_ids_q, next_fetch_date, appointment_schedules,
-                                       page=1 + max(0, floor(diff.days / DOCTOLIB_DAYS_PER_PAGE)) + page,
-                                       first_availability=first_availability)
+            return self.get_timetables(
+                request,
+                visit_motive_ids,
+                visit_motive_id,
+                agenda_ids_q,
+                practice_ids_q,
+                next_fetch_date,
+                appointment_schedules,
+                page=1 + max(0, floor(diff.days / DOCTOLIB_DAYS_PER_PAGE)) + page,
+                first_availability=first_availability,
+            )
         if not sdate:
             return first_availability
         if not first_availability or sdate < first_availability:
@@ -203,9 +227,17 @@ class DoctolibSlots:
             request.update_appointment_schedules(schedules)
         if page >= DOCTOLIB_SLOT_PAGES:
             return first_availability
-        return self.get_timetables(request, visit_motive_ids, visit_motive_id, agenda_ids_q,
-                                   practice_ids_q, start_date + timedelta(days=DOCTOLIB_DAYS_PER_PAGE),
-                                   appointment_schedules, 1 + page, first_availability=first_availability)
+        return self.get_timetables(
+            request,
+            visit_motive_ids,
+            visit_motive_id,
+            agenda_ids_q,
+            practice_ids_q,
+            start_date + timedelta(days=DOCTOLIB_DAYS_PER_PAGE),
+            appointment_schedules,
+            1 + page,
+            first_availability=first_availability,
+        )
 
     def sort_agenda_ids(self, all_agendas, ids):
         """
@@ -251,16 +283,16 @@ class DoctolibSlots:
         return False
 
     def get_appointments(
-            self,
-            request: ScraperRequest,
-            start_date: str,
-            visit_motive_ids,
-            motive_id: str,
-            agenda_ids_q: str,
-            practice_ids_q: str,
-            limit: int,
-            start_date_original: str,
-            appointment_schedules: list,
+        self,
+        request: ScraperRequest,
+        start_date: str,
+        visit_motive_ids,
+        motive_id: str,
+        agenda_ids_q: str,
+        practice_ids_q: str,
+        limit: int,
+        start_date_original: str,
+        appointment_schedules: list,
     ):
         stop = False
         motive_availability = False
@@ -329,7 +361,7 @@ class DoctolibSlots:
                 if append_date_days(start_date_original, 0) <= append_date_days(start_date_original, interval):
                     if availability.get("date"):
                         if append_date_days(availability.get("date"), 0) < append_date_days(
-                                start_date_original, interval
+                            start_date_original, interval
                         ):
                             appointment_schedules = build_appointment_schedules(
                                 request,
@@ -474,7 +506,7 @@ def _parse_practice_id(rdv_site_web: str):
 
 
 def build_appointment_schedules(
-        request, interval, start_date, end_date, count, appointment_schedules, chronodose=False
+    request, interval, start_date, end_date, count, appointment_schedules, chronodose=False
 ):
     if appointment_schedules is None:
         appointment_schedules = []
@@ -566,7 +598,7 @@ def _find_visit_motive_id(rdata: dict, visit_motive_category_id: list = None):
 
 
 def _find_agenda_and_practice_ids(
-        data: dict, visit_motive_id: str, practice_id_filter: list = None
+    data: dict, visit_motive_id: str, practice_id_filter: list = None
 ) -> Tuple[list, list]:
     """
     Etant donné une réponse à /booking/<centre>.json, renvoie tous les
@@ -577,9 +609,9 @@ def _find_agenda_and_practice_ids(
     practice_ids = set()
     for agenda in data.get("agendas", []):
         if (
-                "practice_id" in agenda
-                and practice_id_filter is not None
-                and agenda["practice_id"] not in practice_id_filter
+            "practice_id" in agenda
+            and practice_id_filter is not None
+            and agenda["practice_id"] not in practice_id_filter
         ):
             continue
         if agenda["booking_disabled"]:

--- a/scraper/pattern/scraper_request.py
+++ b/scraper/pattern/scraper_request.py
@@ -13,6 +13,7 @@ class ScraperRequest:
         self.vaccine_type = None
         self.appointment_by_phone_only = False
         self.requests = None
+        self.input_data = None
 
     def update_internal_id(self, internal_id: str) -> Optional[str]:
         self.internal_id = internal_id

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -97,7 +97,7 @@ def cherche_prochain_rdv_dans_centre(centre: dict) -> CenterInfo:  # pragma: no 
     has_error = None
     result = None
     try:
-        result = fetch_centre_slots(centre["rdv_site_web"], start_date)
+        result = fetch_centre_slots(centre["rdv_site_web"], start_date, input_data=centre.get("booking"))
         center_data.fill_result(result)
     except ScrapeError as scrape_error:
         logger.error(f"erreur lors du traitement de la ligne avec le gid {centre['gid']} {str(scrape_error)}")
@@ -167,7 +167,7 @@ def get_center_platform(center_url: str, fetch_map: dict = None):
 
 
 @Profiling.measure("Any_slot")
-def fetch_centre_slots(rdv_site_web, start_date, fetch_map: dict = None) -> ScraperResult:
+def fetch_centre_slots(rdv_site_web, start_date, fetch_map: dict = None, input_data: dict = None) -> ScraperResult:
     if fetch_map is None:
         # Map platform to implementation.
         # May be overridden for unit testing purposes.
@@ -179,6 +179,8 @@ def fetch_centre_slots(rdv_site_web, start_date, fetch_map: dict = None) -> Scra
 
     if not platform:
         return ScraperResult(request, "Autre", None)
+    if input_data:
+        request.input_data = input_data
     # Dispatch to appropriate implementation.
     fetch_impl = fetch_map[platform]["scraper_ptr"]
     result = ScraperResult(request, platform, None)

--- a/tests/test_center_info.py
+++ b/tests/test_center_info.py
@@ -56,7 +56,7 @@ def test_center_info_fill():
         "erreur": None,
         "last_scan_with_availabilities": None,
         "appointment_schedules": None,
-        "request_counts": None
+        "request_counts": None,
     }
 
 

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -184,7 +184,7 @@ def test_parse_centre():
 
     # Ancienne URL
     url = "https://www.doctolib.fr/centre-de-vaccinations-internationales/ville2/Centre2"  # noqa
-    _parse_centre(url) == "centre2"
+    assert _parse_centre(url) == "centre2"
 
     # URL invalide
     url = "https://partners.doctolib.fr/centre-de-vaccinations-internationales/ville2/"
@@ -215,12 +215,10 @@ def test_parse_practice_id():
 
 def test_find_visit_motive_category_id():
     data = {
-        "data": {
-            "visit_motive_categories": [
-                {"id": 41, "name": "Professionnels de santé"},
-                {"id": 42, "name": "Non professionnels de santé"},
-            ]
-        }
+        "visit_motive_categories": [
+            {"id": 41, "name": "Professionnels de santé"},
+            {"id": 42, "name": "Non professionnels de santé"},
+        ]
     }
     assert _find_visit_motive_category_id(data) == [42]
 
@@ -228,131 +226,121 @@ def test_find_visit_motive_category_id():
 def test_find_visit_motive_id():
     # Un seul motif dispo
     data = {
-        "data": {
-            "visit_motives": [
-                {
-                    "id": 1,
-                    "visit_motive_category_id": 42,
-                    "name": "1ère injection vaccin COVID-19 (Moderna)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                }
-            ]
-        }
+        "visit_motives": [
+            {
+                "id": 1,
+                "visit_motive_category_id": 42,
+                "name": "1ère injection vaccin COVID-19 (Moderna)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            }
+        ]
     }
     assert _find_visit_motive_id(data, visit_motive_category_id=[42]) == {1: Vaccine.MODERNA}
 
     # Plusieurs motifs dispo
     data = {
-        "data": {
-            "visit_motives": [
-                {
-                    "id": 1,
-                    "visit_motive_category_id": 42,
-                    "name": "1ère injection vaccin COVID-19 (Pfizer/BioNTech)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-                {
-                    "id": 2,
-                    "name": "1ère injection vaccin COVID-19 (Moderna)",
-                    "visit_motive_category_id": 42,
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-            ]
-        }
+        "visit_motives": [
+            {
+                "id": 1,
+                "visit_motive_category_id": 42,
+                "name": "1ère injection vaccin COVID-19 (Pfizer/BioNTech)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+            {
+                "id": 2,
+                "name": "1ère injection vaccin COVID-19 (Moderna)",
+                "visit_motive_category_id": 42,
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+        ]
     }
     assert _find_visit_motive_id(data, visit_motive_category_id=[42]) == {1: Vaccine.PFIZER, 2: Vaccine.MODERNA}
 
     # Mix avec un motif autre
     data = {
-        "data": {
-            "visit_motives": [
-                {"id": 1, "visit_motive_category_id": 42, "name": "Autre motif"},
-                {
-                    "id": 2,
-                    "visit_motive_category_id": 42,
-                    "name": "1ère injection vaccin COVID-19 (Moderna)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-            ]
-        }
+        "visit_motives": [
+            {"id": 1, "visit_motive_category_id": 42, "name": "Autre motif"},
+            {
+                "id": 2,
+                "visit_motive_category_id": 42,
+                "name": "1ère injection vaccin COVID-19 (Moderna)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+        ]
     }
     assert _find_visit_motive_id(data, visit_motive_category_id=[42]) == {2: Vaccine.MODERNA}
 
     # Mix avec une catégorie autre
     data = {
-        "data": {
-            "visit_motives": [
-                {
-                    "id": 1,
-                    "visit_motive_category_id": 41,
-                    "name": "1ère injection vaccin COVID-19 (Moderna)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-                {
-                    "id": 2,
-                    "visit_motive_category_id": 42,
-                    "name": "1ère injection vaccin COVID-19 (AstraZeneca)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-            ]
-        }
+        "visit_motives": [
+            {
+                "id": 1,
+                "visit_motive_category_id": 41,
+                "name": "1ère injection vaccin COVID-19 (Moderna)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+            {
+                "id": 2,
+                "visit_motive_category_id": 42,
+                "name": "1ère injection vaccin COVID-19 (AstraZeneca)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+        ]
     }
     assert _find_visit_motive_id(data, visit_motive_category_id=[42]) == {2: Vaccine.ASTRAZENECA}
 
     # Plusieurs types de vaccin
     data = {
-        "data": {
-            "visit_motives": [
-                {
-                    "id": 1,
-                    "visit_motive_category_id": 42,
-                    "name": "1ère injection vaccin COVID-19 (Moderna)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-                {
-                    "id": 2,
-                    "visit_motive_category_id": 42,
-                    "name": "1ère injection vaccin COVID-19 (AstraZeneca)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-                {
-                    "id": 3,
-                    "visit_motive_category_id": 42,
-                    "name": "1ère injection vaccin COVID-19 (Pfizer-BioNTech)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": True,
-                },
-                {
-                    "id": 4,
-                    "visit_motive_category_id": 42,
-                    "name": "2nde injection vaccin COVID-19 (Moderna)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": False,
-                },
-                {
-                    "id": 5,
-                    "visit_motive_category_id": 42,
-                    "name": "2nde injection vaccin COVID-19 (AstraZeneca)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": False,
-                },
-                {
-                    "id": 6,
-                    "visit_motive_category_id": 42,
-                    "name": "2nde injection vaccin COVID-19 (Pfizer-BioNTech)",
-                    "vaccination_motive": True,
-                    "first_shot_motive": False,
-                },
-            ]
-        }
+        "visit_motives": [
+            {
+                "id": 1,
+                "visit_motive_category_id": 42,
+                "name": "1ère injection vaccin COVID-19 (Moderna)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+            {
+                "id": 2,
+                "visit_motive_category_id": 42,
+                "name": "1ère injection vaccin COVID-19 (AstraZeneca)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+            {
+                "id": 3,
+                "visit_motive_category_id": 42,
+                "name": "1ère injection vaccin COVID-19 (Pfizer-BioNTech)",
+                "vaccination_motive": True,
+                "first_shot_motive": True,
+            },
+            {
+                "id": 4,
+                "visit_motive_category_id": 42,
+                "name": "2nde injection vaccin COVID-19 (Moderna)",
+                "vaccination_motive": True,
+                "first_shot_motive": False,
+            },
+            {
+                "id": 5,
+                "visit_motive_category_id": 42,
+                "name": "2nde injection vaccin COVID-19 (AstraZeneca)",
+                "vaccination_motive": True,
+                "first_shot_motive": False,
+            },
+            {
+                "id": 6,
+                "visit_motive_category_id": 42,
+                "name": "2nde injection vaccin COVID-19 (Pfizer-BioNTech)",
+                "vaccination_motive": True,
+                "first_shot_motive": False,
+            },
+        ]
     }
     assert _find_visit_motive_id(data, visit_motive_category_id=[42]) == {
         1: Vaccine.MODERNA,
@@ -363,36 +351,34 @@ def test_find_visit_motive_id():
 
 def test_find_agenda_and_practice_ids():
     data = {
-        "data": {
-            "agendas": [
-                {
-                    "id": 10,
-                    "practice_id": 20,
-                    "booking_disabled": False,
-                    "visit_motive_ids_by_practice_id": {
-                        "20": [1, 2],
-                        "21": [1],
-                        "22": [2],  # => Pas inclus
-                    },
+        "agendas": [
+            {
+                "id": 10,
+                "practice_id": 20,
+                "booking_disabled": False,
+                "visit_motive_ids_by_practice_id": {
+                    "20": [1, 2],
+                    "21": [1],
+                    "22": [2],  # => Pas inclus
                 },
-                {
-                    "id": 11,
-                    "booking_disabled": True,  # => Pas inclus
-                    "visit_motive_ids_by_practice_id": {
-                        "23": [1, 2],
-                    },
+            },
+            {
+                "id": 11,
+                "booking_disabled": True,  # => Pas inclus
+                "visit_motive_ids_by_practice_id": {
+                    "23": [1, 2],
                 },
-                {
-                    "id": 12,
-                    "practice_id": 21,
-                    "booking_disabled": False,
-                    "visit_motive_ids_by_practice_id": {
-                        "21": [1, 2],
-                        "24": [1],
-                    },
+            },
+            {
+                "id": 12,
+                "practice_id": 21,
+                "booking_disabled": False,
+                "visit_motive_ids_by_practice_id": {
+                    "21": [1, 2],
+                    "24": [1],
                 },
-            ],
-        },
+            },
+        ],
     }
     agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=1)
     assert agenda_ids == ["10", "12"]

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -7,7 +7,7 @@ from scraper.doctolib.doctolib_center_scrap import (
     get_dict_infos_center_page,
     parse_page_centers_departement,
     parse_pages_departement,
-    parse_doctolib_centers
+    parse_doctolib_centers,
 )
 
 import requests
@@ -113,6 +113,8 @@ def test_get_dict_infos_center_page(mock_get):
             "visit_motives": ["Consultation de suivi spécialiste", "Première consultation de neurochirurgie"],
         },
     ]
+
+
 #    mock_get.return_value.json.return_value = booking
 #    mockedResponse = get_dict_infos_center_page("someURL?pid=practice-86656")
 #    assert mockedResponse == expectedInfosCenterPageWithLandlineNumber
@@ -151,7 +153,13 @@ def test_centers_parsing(mock_get):
             "type": "drugstore",
             "ville": "Villejuif",
             "visit_motives": ["Consultation de suivi spécialiste", "Première consultation de neurochirurgie"],
-            "booking":  {'profile': {'id': 1, 'name_with_title': 'Hopital test'}, 'visit_motives': [{'name': 'Consultation de suivi spécialiste'}, {'name': 'Première consultation de neurochirurgie'}]}
+            "booking": {
+                "profile": {"id": 1, "name_with_title": "Hopital test"},
+                "visit_motives": [
+                    {"name": "Consultation de suivi spécialiste"},
+                    {"name": "Première consultation de neurochirurgie"},
+                ],
+            },
         },
         {
             "address": "22b Rue Jean Jaurès, 94800 Villejuif",
@@ -221,13 +229,19 @@ def test_centers_parsing(mock_get):
             "type": "vaccination-center",
             "ville": "Le Petit-Quevilly",
             "visit_motives": ["Consultation de suivi spécialiste", "Première consultation de neurochirurgie"],
-            "booking": {'profile': {'id': 1, 'name_with_title': 'Hopital test'},
-                        'visit_motives': [{'name': 'Consultation de suivi spécialiste'},
-                                          {'name': 'Première consultation de neurochirurgie'}]}
-        }
+            "booking": {
+                "profile": {"id": 1, "name_with_title": "Hopital test"},
+                "visit_motives": [
+                    {"name": "Consultation de suivi spécialiste"},
+                    {"name": "Première consultation de neurochirurgie"},
+                ],
+            },
+        },
     ]
 
     mock_get.return_value.json.return_value = doctors
+
+
 #
 #    mockedResponse, stop = parse_page_centers_departement("", 1, [])
 #    with open('tests/fixtures/doctolib/booking-with-doctors.json', 'w') as f:

--- a/tests/test_mapharma.py
+++ b/tests/test_mapharma.py
@@ -53,6 +53,7 @@ def test_fetch_slots():
     first_availability = fetch_slots(request, client, opendata_file=TEST_OPEN_DATA_FILE)
     assert first_availability == None
 
+
 def test_campaign_to_center():
     pharma = {
         "code_postal": "35000",

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -143,7 +143,7 @@ def test_export_data(tmp_path):
                 "vaccine_type": None,
                 "erreur": None,
                 "last_scan_with_availabilities": None,
-                "request_counts": None
+                "request_counts": None,
             },
         ],
         "centres_indisponibles": [],
@@ -170,7 +170,7 @@ def test_export_data(tmp_path):
                 "vaccine_type": None,
                 "erreur": None,
                 "last_scan_with_availabilities": None,
-                "request_counts": None
+                "request_counts": None,
             },
         ],
         "centres_indisponibles": [
@@ -189,7 +189,7 @@ def test_export_data(tmp_path):
                 "vaccine_type": None,
                 "erreur": None,
                 "last_scan_with_availabilities": None,
-                "request_counts": None
+                "request_counts": None,
             }
         ],
         "last_scrap": [],
@@ -216,7 +216,7 @@ def test_export_data(tmp_path):
                 "vaccine_type": None,
                 "erreur": None,
                 "last_scan_with_availabilities": None,
-                "request_counts": None
+                "request_counts": None,
             },
         ],
         "last_scrap": [],
@@ -243,7 +243,7 @@ def test_export_data(tmp_path):
                 "vaccine_type": None,
                 "erreur": None,
                 "last_scan_with_availabilities": None,
-                "request_counts": None
+                "request_counts": None,
             },
         ],
         "centres_indisponibles": [],
@@ -382,7 +382,7 @@ def test_export_data_when_blocked(tmp_path):
                 "appointment_by_phone_only": False,
                 "erreur": "ERREUR DE SCRAPPING (Doctolib): Doctolib bloque nos appels: 403 https://example.com/hopital-magique",
                 "last_scan_with_availabilities": None,
-                "request_counts": None
+                "request_counts": None,
             }
         ],
         "doctolib_bloqué": True,
@@ -408,7 +408,7 @@ def test_export_data_when_blocked(tmp_path):
                 "vaccine_type": None,
                 "erreur": None,
                 "last_scan_with_availabilities": None,
-                "request_counts": None
+                "request_counts": None,
             },
         ],
         "centres_indisponibles": [],


### PR DESCRIPTION
**Description**

Deuxième partie de l'optimisation des requêtes avec Doctolib. J'ai ajouté la possibilité d'envoyer des données en "input" au fetch_slots (qui est utile en l'occurrence pour les données de l'endpoint booking). Ca permet d'envoyer les données de la requête 'booking' que l'on fait dans le scraper Doctolib (et qui est dans le JSON du scraper).

Ca permet de ne plus utiliser l'endpoint booking à chaque fois que l'on fetch les créneaux sur les centres /!\

Actuellement, en utilisant l'endpoint `requests` à chaque scrape des créneaux (nombre de requêtes) : 

```
+----------+-------+------------+----------+---------+---------+----------+-------+
| Platform | Total | next-slots | resource | booking | motives | cabinets | slots |
+----------+-------+------------+----------+---------+---------+----------+-------+
| Doctolib | 6079  | 0          | 0        | 2091    | 0       | 0        | 3988  |
+----------+-------+------------+----------+---------+---------+----------+-------+
```

En prenant les informations `booking` depuis le doctolib-centers.json : 

```
+----------+-------+------------+----------+---------+---------+----------+-------+
| Platform | Total | next-slots | resource | booking | motives | cabinets | slots |
+----------+-------+------------+----------+---------+---------+----------+-------+
| Doctolib | 4006  | 0          | 0        | 0       | 0       | 0        | 4006  |
+----------+-------+------------+----------+---------+---------+----------+-------+
```

Ca ferait baisser de ~30% au minimum le nombre de requêtes que l'on envoie à Doctolib avec le scraper de créneaux en utilisant cette méthode (sans compter toutes les autres optimisations sur les timetables que j'ai mis en place il y a peu)

**Checklist**

- [ ] J'ai ajouté des tests (si nécessaire)
- [X] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`