### PR TITLE
[DOCTOLIB] - Ajout de motifs manquants

### DIFF
--- a/config.json
+++ b/config.json
@@ -132,7 +132,22 @@
           "vaccination covid",
           "vaccination pfizer",
           "assesseur",
-          "vote"
+          "vote",
+          "pharmacien",
+          "vaccin",
+          "réservation en ligne",
+          "réservable en ligne",
+          "comorbidités",
+          "enceinte",
+          "immunodéprimée"
+          "18",
+          "consultation",
+          "eligibles",
+          "très haut risque",
+          "moderna",
+          "astra",
+          "astrazeneca",
+          "pré-consultation"
         ]
       },
       "center_scraper": {

--- a/config.json
+++ b/config.json
@@ -139,7 +139,7 @@
           "réservable en ligne",
           "comorbidités",
           "enceinte",
-          "immunodéprimée"
+          "immunodéprimée",
           "18",
           "consultation",
           "eligibles",


### PR DESCRIPTION
J'ai scrapé l'ensemble des centres sur doctolib, et regardé les vaccination_motive = True pour lesquels nous avions is_category_relevant = False

J'ai regardé à la main tous ces motifs, et j'ajoute donc ceux qui manquent actuellement :)

Du coup, on devrait récupérer pas mal de centres qui manquaient !!
