### PR TITLE
Clean up unused imports and variables

### DIFF
--- a/dev/model/department.py
+++ b/dev/model/department.py
@@ -22,13 +22,11 @@ import json
 from datetime import datetime
 from itertools import chain
 from pathlib import Path
-from scraper.pattern.center_info import VACCINES_NAMES
 from typing import Dict, Iterator, List, Optional
 
 from pydantic import BaseModel, Field
 
 from dev.model.schedule import Schedule
-from scraper.pattern.center_location import CenterLocation
 from scraper.pattern.center_info import Vaccine
 
 

--- a/dev/model/schedule.py
+++ b/dev/model/schedule.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class Schedule(BaseModel):

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -1,8 +1,5 @@
 import multiprocessing
-from time import sleep, time
 from scraper.pattern.scraper_result import (
-    DRUG_STORE,
-    GENERAL_PRACTITIONER,
     VACCINATION_CENTER,
 )
 from utils.vmd_config import get_conf_platform, get_conf_inputs
@@ -16,7 +13,6 @@ import requests
 import json
 from urllib import parse
 import requests
-import os
 import re
 from unidecode import unidecode
 

--- a/scraper/export/export_pool.py
+++ b/scraper/export/export_pool.py
@@ -1,27 +1,19 @@
-import sys
-import csv
 import datetime as dt
-import io
 import json
 import os
-import traceback
-from collections import deque
-from multiprocessing import Pool
-from typing import Counter, Iterator, List
-from scraper.profiler import Profiling, ProfiledPool
+from typing import Iterator
 
-from scraper.error import ScrapeError, BlockedByDoctolibError
+from scraper.error import BlockedByDoctolibError
 
 import pytz
-import requests
 
-from scraper.pattern.center_info import convert_csv_data_to_center_info, CenterInfo
+from scraper.pattern.center_info import CenterInfo
 from utils.vmd_blocklist import is_in_blocklist, get_blocklist_urls
 from utils.vmd_center_sort import sort_center
 from utils.vmd_duplicated import deduplicates_names
-from utils.vmd_logger import enable_logger_for_production, enable_logger_for_debug, get_logger
+from utils.vmd_logger import get_logger
 from utils.vmd_opendata import copy_omit_keys
-from utils.vmd_utils import departementUtils, fix_scrap_urls, is_reserved_center, get_last_scans
+from utils.vmd_utils import is_reserved_center
 
 POOL_SIZE = int(os.getenv("POOL_SIZE", 50))
 PARTIAL_SCRAPE = float(os.getenv("PARTIAL_SCRAPE", 1.0))

--- a/scraper/keldoc/keldoc.py
+++ b/scraper/keldoc/keldoc.py
@@ -1,6 +1,5 @@
 import os
 import logging
-from datetime import datetime, timedelta
 
 import httpx
 

--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -269,8 +269,6 @@ class KeldocCenter:
             if "id" not in relevant_motive or "agendas" not in relevant_motive:
                 continue
             motive_id = relevant_motive.get("id", None)
-            API_KELDOC_CALENDAR.format(motive_id)
-
             agenda_ids = relevant_motive.get("agendas", None)
             if not agenda_ids:
                 continue

--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -12,7 +12,7 @@ import httpx
 from scraper.keldoc.keldoc_filters import parse_keldoc_availability
 from scraper.keldoc.keldoc_routes import API_KELDOC_CALENDAR, API_KELDOC_CENTER, API_KELDOC_CABINETS
 from scraper.pattern.scraper_request import ScraperRequest
-from scraper.pattern.center_info import get_vaccine_name, Vaccine, INTERVAL_SPLIT_DAYS, CHRONODOSES
+from scraper.pattern.center_info import INTERVAL_SPLIT_DAYS
 from utils.vmd_config import get_conf_platform
 
 KELDOC_CONF = get_conf_platform("keldoc")
@@ -269,7 +269,7 @@ class KeldocCenter:
             if "id" not in relevant_motive or "agendas" not in relevant_motive:
                 continue
             motive_id = relevant_motive.get("id", None)
-            calendar_url = API_KELDOC_CALENDAR.format(motive_id)
+            API_KELDOC_CALENDAR.format(motive_id)
 
             agenda_ids = relevant_motive.get("agendas", None)
             if not agenda_ids:

--- a/scraper/maiia/maiia.py
+++ b/scraper/maiia/maiia.py
@@ -7,13 +7,12 @@ from pytz import timezone
 
 import requests
 from dateutil.parser import isoparse
-from pathlib import Path
 from urllib import parse as urlparse
 from urllib.parse import quote, parse_qs
 from typing import Optional, Tuple
 
 from scraper.profiler import Profiling
-from scraper.pattern.center_info import get_vaccine_name, Vaccine, INTERVAL_SPLIT_DAYS, CHRONODOSES
+from scraper.pattern.center_info import CHRONODOSES, INTERVAL_SPLIT_DAYS, get_vaccine_name
 from scraper.pattern.scraper_request import ScraperRequest
 from scraper.maiia.maiia_utils import get_paged, MAIIA_LIMIT
 from utils.vmd_config import get_conf_platform, get_config

--- a/scraper/maiia/maiia_center_scrap.py
+++ b/scraper/maiia/maiia_center_scrap.py
@@ -2,15 +2,13 @@ import httpx
 import json
 import logging
 
-from datetime import datetime, timedelta
-from dateutil.parser import isoparse
 from pathlib import Path
 
 from utils.vmd_config import get_conf_platform
 from utils.vmd_utils import departementUtils, format_phone_number
 from scraper.pattern.center_info import get_vaccine_name
-from scraper.pattern.scraper_result import DRUG_STORE, GENERAL_PRACTITIONER, VACCINATION_CENTER
-from .maiia_utils import get_paged, MAIIA_LIMIT
+from scraper.pattern.scraper_result import DRUG_STORE, VACCINATION_CENTER
+from .maiia_utils import get_paged
 
 MAIIA_CONF = get_conf_platform("maiia")
 MAIIA_API = MAIIA_CONF.get("api", {})

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 
 from scraper.export.export_merge import merge_platforms
 from scraper.scraper import scrape, scrape_debug

--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -7,15 +7,13 @@ import logging
 from datetime import date, datetime, timedelta
 from dateutil.parser import isoparse
 from pytz import timezone
-from urllib.parse import parse_qs
-from bs4 import BeautifulSoup
 from pathlib import Path
 from urllib import parse
 from typing import Optional
 
 from scraper.pattern.scraper_request import ScraperRequest
 from scraper.pattern.scraper_result import DRUG_STORE
-from scraper.pattern.center_info import get_vaccine_name, Vaccine, INTERVAL_SPLIT_DAYS, CHRONODOSES
+from scraper.pattern.center_info import CHRONODOSES, INTERVAL_SPLIT_DAYS, get_vaccine_name
 from utils.vmd_config import get_conf_platform
 from utils.vmd_utils import departementUtils
 from scraper.profiler import Profiling
@@ -53,7 +51,7 @@ def campagne_to_centre(pharmacy: dict, campagne: dict) -> dict:
     if not pharmacy.get("code_postal"):
         raise ValueError("Absence de code postal")
     insee = departementUtils.cp_to_insee(pharmacy.get("code_postal"))
-    departement = departementUtils.to_departement_number(insee)
+    departementUtils.to_departement_number(insee)
     centre = dict()
     centre["nom"] = pharmacy.get("nom")
     centre["type"] = DRUG_STORE
@@ -265,7 +263,6 @@ def is_campagne_valid(campagne: dict) -> bool:
 def centre_iterator():
     global opendata
     global campagnes_inconnues
-    campagnes = []
     opendata = get_mapharma_opendata()
     if not opendata:
         logger.error("Mapharma unable to get centre list")

--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -51,7 +51,6 @@ def campagne_to_centre(pharmacy: dict, campagne: dict) -> dict:
     if not pharmacy.get("code_postal"):
         raise ValueError("Absence de code postal")
     insee = departementUtils.cp_to_insee(pharmacy.get("code_postal"))
-    departementUtils.to_departement_number(insee)
     centre = dict()
     centre["nom"] = pharmacy.get("nom")
     centre["type"] = DRUG_STORE

--- a/scraper/opendata/opendata.py
+++ b/scraper/opendata/opendata.py
@@ -4,7 +4,7 @@ import json
 from typing import Iterator
 import requests
 
-from utils.vmd_logger import enable_logger_for_production, get_logger
+from utils.vmd_logger import get_logger
 from utils.vmd_utils import fix_scrap_urls
 
 logger = get_logger()

--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from dateutil.parser import isoparse
 from pytz import timezone
 
-from scraper.pattern.center_info import get_vaccine_name, Vaccine, INTERVAL_SPLIT_DAYS, CHRONODOSES
+from scraper.pattern.center_info import CHRONODOSES, INTERVAL_SPLIT_DAYS, get_vaccine_name
 from scraper.pattern.scraper_request import ScraperRequest
 from scraper.pattern.scraper_result import DRUG_STORE
 from utils.vmd_config import get_conf_platform
@@ -172,7 +172,7 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
     profile = get_profile(request, client)
     if not profile:
         return None
-    slug = profile["profileSlug"]
+    profile["profileSlug"]
     entityId = profile["entityId"]
     attributes = profile.get("attributeValues")
     for settings in attributes:
@@ -193,8 +193,8 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
         )
     for professional in profile["publicProfessionals"]:
         medicalStaffId = professional["id"]
-        name = professional["fullName"]
-        zip = professional["zip"]
+        professional["fullName"]
+        professional["zip"]
         reasons = get_reasons(entityId, request=request)
         for reason in reasons["reasons"]:
             if not is_reason_valid(reason):

--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -172,7 +172,6 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
     profile = get_profile(request, client)
     if not profile:
         return None
-    profile["profileSlug"]
     entityId = profile["entityId"]
     attributes = profile.get("attributeValues")
     for settings in attributes:
@@ -193,8 +192,6 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
         )
     for professional in profile["publicProfessionals"]:
         medicalStaffId = professional["id"]
-        professional["fullName"]
-        professional["zip"]
         reasons = get_reasons(entityId, request=request)
         for reason in reasons["reasons"]:
             if not is_reason_valid(reason):

--- a/scraper/pattern/center_info.py
+++ b/scraper/pattern/center_info.py
@@ -7,7 +7,6 @@ import pytz
 from utils.vmd_config import get_config
 from utils.vmd_utils import departementUtils
 from scraper.pattern.center_location import CenterLocation, convert_csv_data_to_location
-from scraper.pattern.scraper_request import ScraperRequest
 from scraper.pattern.scraper_result import ScraperResult
 
 from utils.vmd_utils import urlify, format_phone_number
@@ -151,7 +150,6 @@ def convert_ordoclic_to_center_info(data: dict, center: CenterInfo) -> CenterInf
 def convert_csv_data_to_center_info(data: dict) -> CenterInfo:
     name = data.get("nom", None)
     departement = ""
-    ville = ""
     url = data.get("rdv_site_web", None)
     try:
         departement = departementUtils.to_departement_number(data.get("com_insee", None))

--- a/scraper/pattern/scraper_request.py
+++ b/scraper/pattern/scraper_request.py
@@ -1,4 +1,3 @@
-import hashlib
 from typing import Optional
 
 

--- a/scraper/pattern/scraper_result.py
+++ b/scraper/pattern/scraper_result.py
@@ -1,5 +1,3 @@
-import json
-from enum import Enum
 
 from scraper.pattern.scraper_request import ScraperRequest
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -2,7 +2,6 @@ import os
 import traceback
 from collections import deque
 from multiprocessing import Pool
-from pprint import pformat
 from random import random
 
 from scraper.error import ScrapeError
@@ -41,7 +40,7 @@ def scrape_debug(urls):  # pragma: no cover
         logger.info("scraping URL %s", rdv_site_web)
         try:
             result = fetch_centre_slots(rdv_site_web, start_date)
-        except Exception as e:
+        except Exception:
             logger.exception(f"erreur lors du traitement")
         logger.info(f'{result.platform!s:16} {result.next_availability or ""!s:32}')
         if result.request.appointment_count:
@@ -102,7 +101,7 @@ def cherche_prochain_rdv_dans_centre(centre: dict) -> CenterInfo:  # pragma: no 
     except ScrapeError as scrape_error:
         logger.error(f"erreur lors du traitement de la ligne avec le gid {centre['gid']} {str(scrape_error)}")
         has_error = scrape_error
-    except Exception as e:
+    except Exception:
         logger.error(f"erreur lors du traitement de la ligne avec le gid {centre['gid']}")
         traceback.print_exc()
 

--- a/scripts/test
+++ b/scripts/test
@@ -4,6 +4,6 @@ BIN="venv/bin/"
 
 set -x
 
-${BIN}coverage run -m pytest --ignore tests/ -vv
+${BIN}coverage run -m pytest --ignore tests/
 
 scripts/coverage

--- a/stats_generation/stats_available_centers.py
+++ b/stats_generation/stats_available_centers.py
@@ -30,9 +30,8 @@ def generate_stats_date(centres_stats):
         data = history_rq.json()
         if data:
             stats_data = data
-    except Exception as e:
+    except Exception:
         logger.warning(f"Unable to fetch {DATA_AUTO}{stats_path}: generating a template file.")
-        pass
     ctz = pytz.timezone("Europe/Paris")
     current_time = datetime.now(tz=ctz).strftime("%Y-%m-%d %H:00:00")
     if current_time in stats_data["dates"]:
@@ -65,9 +64,8 @@ def generate_stats_dep_date(centres_stats):
         data = history_rq.json()
         if data:
             stats_data = data
-    except Exception as e:
+    except Exception:
         logger.warning(f"Unable to fetch {DATA_AUTO}{stats_path}: generating a template file.")
-        pass
     ctz = pytz.timezone("Europe/Paris")
     current_time = datetime.now(tz=ctz).strftime("%Y-%m-%d %H:00:00")
     if current_time in stats_data["dates"]:

--- a/stats_generation/stats_center_types.py
+++ b/stats_generation/stats_center_types.py
@@ -6,7 +6,6 @@ import pytz
 import requests
 
 from utils.vmd_config import get_conf_outstats
-from utils.vmd_logger import enable_logger_for_production
 
 logger = logging.getLogger("scraper")
 
@@ -64,9 +63,8 @@ def generate_stats_center_types(centres_info):
         data = history_rq.json()
         if data:
             stats_data = data
-    except Exception as e:
+    except Exception:
         logger.warning(f"Unable to fetch {DATA_AUTO}{stats_path}: generating a template file.")
-        pass
     ctz = pytz.timezone("Europe/Paris")
     current_time = datetime.now(tz=ctz).strftime("%Y-%m-%d %H:00:00")
     if current_time in stats_data["dates"]:

--- a/stats_generation/stats_map.py
+++ b/stats_generation/stats_map.py
@@ -2,14 +2,13 @@ import io
 import csv
 import httpx
 import logging
-import time
 
 from datetime import date, datetime, timedelta
 import pytz
 from pathlib import Path
 
 from utils.vmd_config import get_conf_inputs
-from utils.vmd_logger import enable_logger_for_production, enable_logger_for_debug
+from utils.vmd_logger import enable_logger_for_debug
 
 timeout = httpx.Timeout(30.0, connect=30.0)
 DEFAULT_CLIENT = httpx.Client(timeout=timeout)

--- a/tests/dev/model/test_center.py
+++ b/tests/dev/model/test_center.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from dev.model.department import Center, Department, Schedule, load_all
+from dev.model.department import Center, Schedule
 
 
 path = Path("tests", "fixtures", "utils", "info_centres.json")

--- a/tests/test_center_info.py
+++ b/tests/test_center_info.py
@@ -1,10 +1,7 @@
-import datetime as dt
 
-from scraper.pattern.center_location import convert_csv_data_to_location, CenterLocation
+from scraper.pattern.center_location import CenterLocation
 from scraper.pattern.scraper_request import ScraperRequest
 from scraper.pattern.scraper_result import ScraperResult, DRUG_STORE
-from utils.vmd_utils import format_phone_number, get_last_scans
-from .utils import mock_datetime_now
 from scraper.pattern.center_info import (
     CenterInfo,
     convert_csv_address,

--- a/tests/test_center_location.py
+++ b/tests/test_center_location.py
@@ -1,9 +1,5 @@
-import datetime as dt
 
 from scraper.pattern.center_location import convert_csv_data_to_location
-from utils.vmd_utils import format_phone_number, get_last_scans
-from .utils import mock_datetime_now
-from scraper.pattern.center_info import CenterInfo
 
 
 def test_location_working():

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import DefaultDict
 from scraper.doctolib.doctolib_filters import (
     is_category_relevant,
     is_vaccination_center,
@@ -60,7 +59,7 @@ def test_blocked_by_doctolib_par_centre():
 
     error = None
     try:
-        next_date = slots.fetch(scrap_request)
+        slots.fetch(scrap_request)
     except Exception as e:
         error = e
     assert True is isinstance(error, BlockedByDoctolibError)
@@ -87,7 +86,7 @@ def test_blocked_by_doctolib_par_availabilities():
 
     error = None
     try:
-        next_date = slots.fetch(scrap_request)
+        slots.fetch(scrap_request)
     except Exception as e:
         error = e
     assert True is isinstance(error, BlockedByDoctolibError)
@@ -108,7 +107,7 @@ def test_doctolib():
             return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
 
         assert request.url.path == "/availabilities.json"
-        params = dict(httpx.QueryParams(request.url.query))
+        dict(httpx.QueryParams(request.url.query))
         path = Path("tests", "fixtures", "doctolib", "basic-availabilities.json")
         return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
 

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -4,13 +4,8 @@ from scraper.doctolib.doctolib_center_scrap import (
     get_coordinates,
     center_type,
     parse_doctolib_business_hours,
-    get_dict_infos_center_page,
-    parse_page_centers_departement,
-    parse_pages_departement,
-    parse_doctolib_centers,
 )
 
-import requests
 import json
 
 # -- Tests de l'API (offline) --
@@ -65,13 +60,13 @@ def test_doctolib_coordinates():
     assert lat == 8.192
 
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 
 @patch("requests.get")
 def test_get_dict_infos_center_page(mock_get):
     with open("tests/fixtures/doctolib/booking-with-doctors.json", "r") as file:
-        booking = json.load(file)
+        json.load(file)
 
     expectedInfosCenterPageWithLandlineNumber = [
         {

--- a/tests/test_keldoc.py
+++ b/tests/test_keldoc.py
@@ -38,7 +38,7 @@ def online_keldoc_test():
         "2021-04-13",
     )
 
-    slots = fetch_slots(request)
+    fetch_slots(request)
 
 
 def get_test_data(file_name):

--- a/tests/test_mapharma.py
+++ b/tests/test_mapharma.py
@@ -1,9 +1,8 @@
 import json
 import httpx
 
-from bs4 import BeautifulSoup
 from pathlib import Path
-from datetime import datetime, date
+from datetime import datetime
 from pytz import timezone
 
 from scraper.mapharma.mapharma import parse_slots, fetch_slots, count_appointements, campagne_to_centre

--- a/tests/test_ordoclic.py
+++ b/tests/test_ordoclic.py
@@ -2,16 +2,12 @@ import json
 import re
 from pathlib import Path
 import httpx
-from datetime import datetime
 from dateutil.parser import isoparse
 from jsonschema import validate
-from jsonschema.exceptions import ValidationError
-import pytest
 
 from scraper.ordoclic import (
     search,
     get_reasons,
-    get_slots,
     get_profile,
     parse_ordoclic_slots,
     fetch_slots,

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -5,7 +5,7 @@ from scraper.export.export_merge import export_data
 from scraper.pattern.center_info import CenterInfo, Vaccine, dict_to_center_info, get_vaccine_name
 from scraper.pattern.scraper_result import GENERAL_PRACTITIONER, ScraperResult
 from utils.vmd_utils import departementUtils
-from scraper.scraper import fetch_centre_slots, get_start_date, gouv_centre_iterator, ialternate
+from scraper.scraper import fetch_centre_slots, get_start_date, gouv_centre_iterator
 from scraper.pattern.scraper_request import ScraperRequest
 from scraper.error import BlockedByDoctolibError
 from .utils import mock_datetime_now

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -17,7 +17,7 @@ def test_stat_count():
     generated_content = output_file.read()
     output_file.close()
     base_file = open("tests/fixtures/stats/stat-output.json", "r")
-    base_content = base_file.read()
+    base_file.read()
     base_file.close()
 
     stats = json.loads(generated_content)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -16,9 +16,6 @@ def test_stat_count():
     output_file = open(f"data/output/{output_file_name}", "r")
     generated_content = output_file.read()
     output_file.close()
-    base_file = open("tests/fixtures/stats/stat-output.json", "r")
-    base_file.read()
-    base_file.close()
 
     stats = json.loads(generated_content)
     assert stats["tout_departement"]["disponibles"] == 280

--- a/utils/vmd_config.py
+++ b/utils/vmd_config.py
@@ -1,5 +1,4 @@
 import json
-import traceback
 from pathlib import Path
 from typing import Optional
 


### PR DESCRIPTION
**Description**

Clean up des imports et des variables non utilisées avec autoflake.

Commande utilisée `autoflake -r --remove-all-unused-imports --remove-unused-variables --ignore-init-module-imports --in-place .`