### PR TITLE
utils: accept phone numbers with international prefix '00'

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,9 @@ def test_format_phone_number():
     phone_number = "3975"
     assert format_phone_number(phone_number) == "+333975"
 
+    phone_number = "0033146871340"
+    assert format_phone_number(phone_number) == "+33146871340"
+
 
 def test_get_last_scans():
 

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -170,7 +170,9 @@ def format_phone_number(_phone_number: str) -> str:
     phone_number = phone_number.replace(".", "")
 
     if not phone_number[0] == "+":
-        if phone_number[0] == "0":
+        if phone_number[:2] == "00":
+            phone_number = "+" + phone_number[2:]
+        elif phone_number[0] == "0":
             phone_number = "+33" + phone_number[1:]
         else:
             phone_number = "+33" + phone_number


### PR DESCRIPTION
**Description**

Les numéros de téléphone de AvecMonDoc sont préfixés par `00`, qui est le [préfixe vers les appels internationaux standard](https://fr.wikipedia.org/wiki/Indicatif_t%C3%A9l%C3%A9phonique_international). Notre fonction `format_phone_number()` ne savait pas gérer ce préfixe, cette PR corrige le problème.

cc @gaelbenoit 
