### PR TITLE
Update doctolib_center_scrap.py

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -125,8 +125,7 @@ def parse_page_centers_departement(departement, page_id, liste_urls) -> Tuple[Li
 
 
 def doctolib_urlify(departement: str) -> str:
-    departement = re.sub(r"[^\w\s\-]", "-", departement)
-    departement = re.sub(r"\s+", "-", departement).lower()
+    departement = re.sub(r"\s+|\W", "-", departement).lower()
     return unidecode(departement)
 
 


### PR DESCRIPTION
A tiny improvement in doctolib_urlify:

reduce two regex replacements to one.

