### PR TITLE
Génère un fichier index.html qui référence les JSON exposés

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ pages:
     - mkdir -p public
     - cp -r data/output/* public/
     - gzip -k -6 $(find public -type f)
+    - scripts/create-index.sh public
   only:
     - main
     - gitlab-publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,8 +46,8 @@ pages:
   script:
     - mkdir -p public
     - cp -r data/output/* public/
-    - gzip -k -6 $(find public -type f)
     - scripts/create-index.sh public
+    - gzip -k -9 $(find public -type f)
   only:
     - main
     - gitlab-publish

--- a/scripts/create-index.sh
+++ b/scripts/create-index.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+cd $1
+
+find -type f -name '*.json' \
+  | cut -c3- \
+  | xargs du -h \
+  | awk 'BEGIN { print "<p>Ressources disponibles</p>\n<ul>"}
+               { print "  <li><a href=\"" $2 "\">"$2" ("$1")</a></li>" }
+         END   { print "</ul>" }' \
+  > index.html


### PR DESCRIPTION
**Description**

<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
On dit beaucoup sur internet que nos données sont ouvertes, mais on ne référence sur data.gouv.fr qu'une seule ressource parce que c'est celle dont on est à peu près sûr qu'on va pas la casser.
Cette PR liste tous les JSON disponibles dans le dossier `/data/output` qui se retrouvent publiés dans un fichier index.html qui sera servi par défaut sur https://vitemadose.gitlab.io/vitemadose

c'est du bash-fu assez basique, mais grosso modo ça fait un `find -name '*.json'` et ça transforme la liste en `<ul> <li/> × 1000 </ul>`
