### PR TITLE
Clean up unused imports and variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+  - repo: git@github.com:humitos/mirrors-autoflake.git
+    rev: v1.1
+    hooks:
+      - id: autoflake
+        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable', '--ignore-init-module-imports']

--- a/dev/model/schedule.py
+++ b/dev/model/schedule.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class Schedule(BaseModel):

--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -12,7 +12,7 @@ import httpx
 from scraper.keldoc.keldoc_filters import parse_keldoc_availability
 from scraper.keldoc.keldoc_routes import API_KELDOC_CALENDAR, API_KELDOC_CENTER, API_KELDOC_CABINETS
 from scraper.pattern.scraper_request import ScraperRequest
-from scraper.pattern.center_info import INTERVAL_SPLIT_DAYS, CHRONODOSES
+from scraper.pattern.center_info import INTERVAL_SPLIT_DAYS
 from utils.vmd_config import get_conf_platform
 
 KELDOC_CONF = get_conf_platform("keldoc")
@@ -269,8 +269,6 @@ class KeldocCenter:
             if "id" not in relevant_motive or "agendas" not in relevant_motive:
                 continue
             motive_id = relevant_motive.get("id", None)
-            calendar_url = API_KELDOC_CALENDAR.format(motive_id)
-
             agenda_ids = relevant_motive.get("agendas", None)
             if not agenda_ids:
                 continue

--- a/scraper/mapharma/mapharma.py
+++ b/scraper/mapharma/mapharma.py
@@ -52,7 +52,6 @@ def campagne_to_centre(pharmacy: dict, campagne: dict) -> dict:
     if not pharmacy.get("code_postal"):
         raise ValueError("Absence de code postal")
     insee = departementUtils.cp_to_insee(pharmacy.get("code_postal"))
-    departement = departementUtils.to_departement_number(insee)
     centre = dict()
     centre["nom"] = pharmacy.get("nom")
     centre["type"] = DRUG_STORE
@@ -264,7 +263,6 @@ def is_campagne_valid(campagne: dict) -> bool:
 def centre_iterator():
     global opendata
     global campagnes_inconnues
-    campagnes = []
     opendata = get_mapharma_opendata()
     if not opendata:
         logger.error("Mapharma unable to get centre list")

--- a/scraper/ordoclic.py
+++ b/scraper/ordoclic.py
@@ -180,7 +180,6 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
     profile = get_profile(request, client)
     if not profile:
         return None
-    slug = profile["profileSlug"]
     entityId = profile["entityId"]
     attributes = profile.get("attributeValues")
     for settings in attributes:
@@ -201,8 +200,6 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT):
         )
     for professional in profile["publicProfessionals"]:
         medicalStaffId = professional["id"]
-        name = professional["fullName"]
-        zip = professional["zip"]
         reasons = get_reasons(entityId, request=request)
         for reason in reasons["reasons"]:
             if not is_reason_valid(reason):

--- a/scraper/pattern/scraper_result.py
+++ b/scraper/pattern/scraper_result.py
@@ -1,5 +1,3 @@
-import json
-from enum import Enum
 
 from scraper.pattern.scraper_request import ScraperRequest
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -40,7 +40,7 @@ def scrape_debug(urls):  # pragma: no cover
         logger.info("scraping URL %s", rdv_site_web)
         try:
             result = fetch_centre_slots(rdv_site_web, start_date)
-        except Exception as e:
+        except Exception:
             logger.exception(f"erreur lors du traitement")
         logger.info(f'{result.platform!s:16} {result.next_availability or ""!s:32}')
         if result.request.appointment_count:
@@ -98,7 +98,7 @@ def cherche_prochain_rdv_dans_centre(centre: dict) -> CenterInfo:  # pragma: no 
     except ScrapeError as scrape_error:
         logger.error(f"erreur lors du traitement de la ligne avec le gid {centre['gid']} {str(scrape_error)}")
         has_error = scrape_error
-    except Exception as e:
+    except Exception:
         logger.error(f"erreur lors du traitement de la ligne avec le gid {centre['gid']}")
         traceback.print_exc()
 

--- a/scripts/test
+++ b/scripts/test
@@ -4,6 +4,6 @@ BIN="venv/bin/"
 
 set -x
 
-${BIN}coverage run -m pytest --ignore tests/ -vv
+${BIN}coverage run -m pytest --ignore tests/
 
 scripts/coverage

--- a/stats_generation/stats_available_centers.py
+++ b/stats_generation/stats_available_centers.py
@@ -30,9 +30,8 @@ def generate_stats_date(centres_stats):
         data = history_rq.json()
         if data:
             stats_data = data
-    except Exception as e:
+    except Exception:
         logger.warning(f"Unable to fetch {DATA_AUTO}{stats_path}: generating a template file.")
-        pass
     ctz = pytz.timezone("Europe/Paris")
     current_time = datetime.now(tz=ctz).strftime("%Y-%m-%d %H:00:00")
     if current_time in stats_data["dates"]:
@@ -65,9 +64,8 @@ def generate_stats_dep_date(centres_stats):
         data = history_rq.json()
         if data:
             stats_data = data
-    except Exception as e:
+    except Exception:
         logger.warning(f"Unable to fetch {DATA_AUTO}{stats_path}: generating a template file.")
-        pass
     ctz = pytz.timezone("Europe/Paris")
     current_time = datetime.now(tz=ctz).strftime("%Y-%m-%d %H:00:00")
     if current_time in stats_data["dates"]:

--- a/stats_generation/stats_center_types.py
+++ b/stats_generation/stats_center_types.py
@@ -6,7 +6,6 @@ import pytz
 import requests
 
 from utils.vmd_config import get_conf_outstats
-from utils.vmd_logger import enable_logger_for_production
 
 logger = logging.getLogger("scraper")
 
@@ -64,9 +63,8 @@ def generate_stats_center_types(centres_info):
         data = history_rq.json()
         if data:
             stats_data = data
-    except Exception as e:
+    except Exception:
         logger.warning(f"Unable to fetch {DATA_AUTO}{stats_path}: generating a template file.")
-        pass
     ctz = pytz.timezone("Europe/Paris")
     current_time = datetime.now(tz=ctz).strftime("%Y-%m-%d %H:00:00")
     if current_time in stats_data["dates"]:

--- a/stats_generation/stats_map.py
+++ b/stats_generation/stats_map.py
@@ -2,14 +2,13 @@ import io
 import csv
 import httpx
 import logging
-import time
 
 from datetime import date, datetime, timedelta
 import pytz
 from pathlib import Path
 
 from utils.vmd_config import get_conf_inputs
-from utils.vmd_logger import enable_logger_for_production, enable_logger_for_debug
+from utils.vmd_logger import enable_logger_for_debug
 
 timeout = httpx.Timeout(30.0, connect=30.0)
 DEFAULT_CLIENT = httpx.Client(timeout=timeout)

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -59,7 +59,7 @@ def test_blocked_by_doctolib_par_centre():
 
     error = None
     try:
-        next_date = slots.fetch(scrap_request)
+        slots.fetch(scrap_request)
     except Exception as e:
         error = e
     assert True is isinstance(error, BlockedByDoctolibError)
@@ -86,7 +86,7 @@ def test_blocked_by_doctolib_par_availabilities():
 
     error = None
     try:
-        next_date = slots.fetch(scrap_request)
+        slots.fetch(scrap_request)
     except Exception as e:
         error = e
     assert True is isinstance(error, BlockedByDoctolibError)
@@ -107,7 +107,7 @@ def test_doctolib():
             return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
 
         assert request.url.path == "/availabilities.json"
-        params = dict(httpx.QueryParams(request.url.query))
+        dict(httpx.QueryParams(request.url.query))
         path = Path("tests", "fixtures", "doctolib", "basic-availabilities.json")
         return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
 

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -1,5 +1,8 @@
 import json
 from pathlib import Path
+
+import pytest
+
 from scraper.doctolib.doctolib_filters import (
     is_category_relevant,
     is_vaccination_center,
@@ -57,12 +60,8 @@ def test_blocked_by_doctolib_par_centre():
     client = httpx.Client(transport=httpx.MockTransport(app))
     slots = DoctolibSlots(client=client, cooldown_interval=0)
 
-    error = None
-    try:
+    with pytest.raises(BlockedByDoctolibError):
         slots.fetch(scrap_request)
-    except Exception as e:
-        error = e
-    assert True is isinstance(error, BlockedByDoctolibError)
 
 
 def test_blocked_by_doctolib_par_availabilities():
@@ -84,12 +83,8 @@ def test_blocked_by_doctolib_par_availabilities():
     client = httpx.Client(transport=httpx.MockTransport(app))
     slots = DoctolibSlots(client=client, cooldown_interval=0)
 
-    error = None
-    try:
+    with pytest.raises(BlockedByDoctolibError):
         slots.fetch(scrap_request)
-    except Exception as e:
-        error = e
-    assert True is isinstance(error, BlockedByDoctolibError)
 
 
 def test_doctolib():

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -107,7 +107,6 @@ def test_doctolib():
             return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
 
         assert request.url.path == "/availabilities.json"
-        dict(httpx.QueryParams(request.url.query))
         path = Path("tests", "fixtures", "doctolib", "basic-availabilities.json")
         return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
 

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -60,13 +60,13 @@ def test_doctolib_coordinates():
     assert lat == 8.192
 
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 
 @patch("requests.get")
 def test_get_dict_infos_center_page(mock_get):
     with open("tests/fixtures/doctolib/booking-with-doctors.json", "r") as file:
-        booking = json.load(file)
+        json.load(file)
 
     expectedInfosCenterPageWithLandlineNumber = [
         {

--- a/tests/test_keldoc.py
+++ b/tests/test_keldoc.py
@@ -38,7 +38,7 @@ def online_keldoc_test():
         "2021-04-13",
     )
 
-    slots = fetch_slots(request)
+    fetch_slots(request)
 
 
 def get_test_data(file_name):

--- a/tests/test_ordoclic.py
+++ b/tests/test_ordoclic.py
@@ -2,7 +2,6 @@ import json
 import re
 from pathlib import Path
 import httpx
-from datetime import datetime
 from dateutil.parser import isoparse
 from jsonschema import validate
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -16,9 +16,6 @@ def test_stat_count():
     output_file = open(f"data/output/{output_file_name}", "r")
     generated_content = output_file.read()
     output_file.close()
-    base_file = open("tests/fixtures/stats/stat-output.json", "r")
-    base_content = base_file.read()
-    base_file.close()
 
     stats = json.loads(generated_content)
     assert stats["tout_departement"]["disponibles"] == 280

--- a/utils/vmd_config.py
+++ b/utils/vmd_config.py
@@ -1,5 +1,4 @@
 import json
-import traceback
 from pathlib import Path
 from typing import Optional
 


### PR DESCRIPTION
**Description**

Clean up des imports et des variables non utilisées avec autoflake.

Commande utilisée `autoflake -r --remove-all-unused-imports --remove-unused-variables --ignore-init-module-imports --in-place .`

Version corrigée :(