### PR TITLE
[AvecMonDoc] date prochain rdv en GMT+2

### DIFF
--- a/scraper/avecmondoc/avecmondoc.py
+++ b/scraper/avecmondoc/avecmondoc.py
@@ -28,7 +28,7 @@ AVECMONDOC_HEADERS = {
     "User-Agent": os.environ.get("AVECMONDOC_API_KEY", ""),
 }
 timeout = httpx.Timeout(AVECMONDOC_CONF.get("timeout", 25), connect=AVECMONDOC_CONF.get("timeout", 25))
-DEFAULT_CLIENT = httpx.Client(headers=AVECMONDOC_HEADERS)
+DEFAULT_CLIENT = httpx.Client(headers=AVECMONDOC_HEADERS, timeout=timeout)
 logger = logging.getLogger("scraper")
 paris_tz = timezone("Europe/Paris")
 
@@ -336,8 +336,9 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT) 
         request.appointment_schedules = appointment_schedules
         if first_availability is None or first_availability > date:
             first_availability = date
-    
-    return(first_availability)
+    if first_availability is None:
+        return None
+    return paris_tz.localize(isoparse(first_availability).replace(tzinfo=None)).isoformat()
 
 
 def center_to_centerdict(center: CenterInfo) -> dict:

--- a/tests/test_avecmondoc.py
+++ b/tests/test_avecmondoc.py
@@ -250,7 +250,7 @@ def test_fetch_slots():
     url = "https://patient.avecmondoc.com/fiche/structure/delphine-rousseau-159"
     request = ScraperRequest(url, "2021-05-20")
     first_availability = avecmondoc.fetch_slots(request, client)
-    assert first_availability == "2021-05-20T09:00:00.000Z"
+    assert first_availability == "2021-05-20T09:00:00+02:00"
     assert request.appointment_count == 108
     assert request.vaccine_type == ["Pfizer-BioNTech"]
 

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -246,7 +246,7 @@ EXPECTED_PARSED_PAGES = [
 
 
 def test_parse_places():
-    with open("tests/fixtures/doctolib/booking-with-doctors.json", "r") as f:
+    with open("tests/fixtures/doctolib/booking-with-doctors.json", "r", encoding='utf8') as f:
         booking = json.load(f)
         assert parse_center_places(booking["data"]) == EXPECTED_PARSED_PAGES
 


### PR DESCRIPTION
**Description**

le format du prochain rdv pose un problème de décalage GMT sur l'app Android
j'en profite pour fixer:
- le timeout pas pris en compte
- forcer l'encodage utf8 qui fait planter les tests sous Windows

