### PR TITLE
Hotfix vaccine type icon shown if it's an empty list on iOS

### DIFF
--- a/scraper/pattern/center_info.py
+++ b/scraper/pattern/center_info.py
@@ -47,7 +47,7 @@ class CenterInfo:
         self.type = None
         self.appointment_count = 0
         self.internal_id = None
-        self.vaccine_type: List[Vaccine] = None
+        self.vaccine_type = None
         self.appointment_by_phone_only = False
         self.erreur = erreur
         self.last_scan_with_availabilities = None

--- a/scraper/pattern/scraper_request.py
+++ b/scraper/pattern/scraper_request.py
@@ -9,7 +9,7 @@ class ScraperRequest:
         self.practitioner_type = None
         self.appointment_count = 0
         self.appointment_schedules = None
-        self.vaccine_type: List[str] = []
+        self.vaccine_type = None
         self.appointment_by_phone_only = False
         self.requests = None
         self.input_data = None
@@ -43,6 +43,9 @@ class ScraperRequest:
         return self.appointment_schedules
 
     def add_vaccine_type(self, vaccine_name: Optional[str]):
+        # Temp fix due to iOS app issues with empty list
+        if self.vaccine_type is None:
+            self.vaccine_type = []
         if vaccine_name and vaccine_name not in self.vaccine_type:
             self.vaccine_type.append(vaccine_name)
 


### PR DESCRIPTION
**Description**

On a fait des changements sans trop prévenir pour le type de vaccin. On renvoie dans le JSON désormais une liste vide si aucun type de vaccin n'a été trouvé, sauf que ça créé un problème au niveau de l'icône du type de vaccin sur l'application iOS, elle est quand-même affichée.

En attendant qu'un fix soit fait au niveau d'iOS et que ça passe en review tout ça tout ça, je me permets de remettre comme c'était à ce niveau.