### PR TITLE
[AvecMonDoc] utc timezone

### DIFF
--- a/scraper/avecmondoc/avecmondoc.py
+++ b/scraper/avecmondoc/avecmondoc.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import re
 from scraper.profiler import Profiling
 from scraper.pattern.scraper_result import DRUG_STORE, GENERAL_PRACTITIONER
 import httpx
@@ -273,7 +272,7 @@ def parse_availabilities(availabilities: list) -> Tuple[Optional[datetime], int]
             if not slot["isAvailable"]:
                 continue
             appointment_count += 1
-            date = slot["businessHours"]["start"]
+            date = isoparse(slot["businessHours"]["start"])
             if first_appointment is None or date < first_appointment:
                 first_appointment = date
     return first_appointment, appointment_count
@@ -338,7 +337,7 @@ def fetch_slots(request: ScraperRequest, client: httpx.Client = DEFAULT_CLIENT) 
             first_availability = date
     if first_availability is None:
         return None
-    return paris_tz.localize(isoparse(first_availability).replace(tzinfo=None)).isoformat()
+    return first_availability.isoformat()
 
 
 def center_to_centerdict(center: CenterInfo) -> dict:

--- a/tests/test_avecmondoc.py
+++ b/tests/test_avecmondoc.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from datetime import datetime
+from dateutil.tz import tzutc
 
 from scraper.avecmondoc import avecmondoc
 
@@ -232,7 +233,7 @@ def test_parse_availabilities():
     data_file = Path("tests/fixtures/avecmondoc/get_availabilities.json")
     data = json.loads(data_file.read_text(encoding='utf8'))
     first_appointment, appointment_count = avecmondoc.parse_availabilities(data)
-    assert  first_appointment == "2021-05-20T09:00:00.000Z"
+    assert  first_appointment == datetime(2021, 5, 20, 9, 0, tzinfo=tzutc())
     assert appointment_count == 12
 
 
@@ -250,7 +251,7 @@ def test_fetch_slots():
     url = "https://patient.avecmondoc.com/fiche/structure/delphine-rousseau-159"
     request = ScraperRequest(url, "2021-05-20")
     first_availability = avecmondoc.fetch_slots(request, client)
-    assert first_availability == "2021-05-20T09:00:00+02:00"
+    assert first_availability == "2021-05-20T09:00:00+00:00"
     assert request.appointment_count == 108
     assert request.vaccine_type == ["Pfizer-BioNTech"]
 


### PR DESCRIPTION
2ème fix pour avoir une heure correcte en retour, les heures de rendez-vous sont en fait renvoyés en UTC
j'en profite pour gérer les heures de rdv au format datetime et pas str