### PR TITLE
Mettre Keldoc au coin quand il ne répond pas assez rapidement 🦆

### DIFF
--- a/scraper/circuit_breaker.py
+++ b/scraper/circuit_breaker.py
@@ -1,22 +1,30 @@
+
+def ShortCircuit(name, trigger=3, release=10):
+    def decorator(fn):
+        breaker = CircuitBreaker(on=fn, name=name, trigger=trigger, release=release)
+        return breaker
+
+    return decorator
+
 # Circuit Breaker helper
 # When ON
 #  - delegates to the `on` parameter function
 #  - if `on()` fails it adds the failure to its count
-#  - if this count exceeds `trigger_count`, the breaker becomes OFF
+#  - if this count exceeds `trigger`, the breaker becomes OFF
 #  - if `on()` succeeds, it decrements the count
 # When OFF
 #  - delefates to the `off` parameter function
 #  - counts the numbers of times `off` is called
-#  - if this counts exceeds `release_count`, the breaker becomes ON
+#  - if this counts exceeds `release`, the breaker becomes ON
 class CircuitBreaker:
-    def __init__(self, on, off=None, trigger_count=3, release_count=10, name=None):
+    def __init__(self, on, off=None, trigger=3, release=10, name=None):
         self.on_func = on
         self.off_func = off
         self.is_on = True
         self.off_count = 0
         self.error_count = 0
-        self.release_count = release_count
-        self.trigger_count = trigger_count
+        self.release = release
+        self.trigger = trigger
         self.name = name
         if name is None and off is None:
             raise Exception("You must specify a name if you don't specify a `off` for CircuitBreaker")
@@ -27,7 +35,7 @@ class CircuitBreaker:
     def call(self, *args, **kwargs):
         if not self.is_on:
             self.off_count += 1
-            if self.off_count <= self.release_count:
+            if self.off_count <= self.release:
                 return self.call_off(*args, **kwargs)
             else:
                 self.is_on = True
@@ -42,7 +50,7 @@ class CircuitBreaker:
 
         except Exception as e:
             self.error_count += 1
-            if self.error_count >= self.trigger_count:
+            if self.error_count >= self.trigger:
                 self.is_on = False
                 self.error_count = 0
             raise e

--- a/scraper/circuit_breaker.py
+++ b/scraper/circuit_breaker.py
@@ -22,7 +22,7 @@ def ShortCircuit(name, trigger=3, release=10, time_limit=120):
 #  - if this counts exceeds `release`, the breaker becomes ON
 class CircuitBreaker:
     def __init__(self, name, on, off=None, trigger=3, release=10, time_limit=120):
-        self.policies = Deque(["ON" for _ in range(trigger)], f'/tmp/breaker/{name}')
+        self.policies = Deque(["ON"] * trigger], f'/tmp/breaker/{name}')
         self.time_limit = time_limit
         self.on_func = on
         self.off_func = off

--- a/scraper/circuit_breaker.py
+++ b/scraper/circuit_breaker.py
@@ -1,0 +1,60 @@
+# Circuit Breaker helper
+# When ON
+#  - delegates to the `on` parameter function
+#  - if `on()` fails it adds the failure to its count
+#  - if this count exceeds `trigger_count`, the breaker becomes OFF
+#  - if `on()` succeeds, it decrements the count
+# When OFF
+#  - delefates to the `off` parameter function
+#  - counts the numbers of times `off` is called
+#  - if this counts exceeds `release_count`, the breaker becomes ON
+class CircuitBreaker:
+    def __init__(self, on, off=None, trigger_count=3, release_count=10, name=None):
+        self.on_func = on
+        self.off_func = off
+        self.is_on = True
+        self.off_count = 0
+        self.error_count = 0
+        self.release_count = release_count
+        self.trigger_count = trigger_count
+        self.name = name
+        if name is None and off is None:
+            raise Exception("You must specify a name if you don't specify a `off` for CircuitBreaker")
+
+    def __call__(self, *args, **kwargs):
+        return self.call(*args, **kwargs)
+
+    def call(self, *args, **kwargs):
+        if not self.is_on:
+            self.off_count += 1
+            if self.off_count <= self.release_count:
+                return self.call_off(*args, **kwargs)
+            else:
+                self.is_on = True
+                self.off_count = 0
+
+        try:
+            value = self.on_func(*args, **kwargs)
+            if self.error_count > 0:
+                self.error_count -= 1
+
+            return value
+
+        except Exception as e:
+            self.error_count += 1
+            if self.error_count >= self.trigger_count:
+                self.is_on = False
+                self.error_count = 0
+            raise e
+
+    def call_off(self, *args, **kwargs):
+        if self.off_func is not None:
+            return self.off_func(*args, **kwargs)
+        else:
+            raise CircuitBreakerOffException(self.name)
+
+class CircuitBreakerOffException(RuntimeError):
+    def __init__(self, name):
+        msg = f"CircuitBreaker '{name}' is currently off"
+        super().__init__(self, msg)
+        self.message = msg

--- a/scraper/keldoc/keldoc_center.py
+++ b/scraper/keldoc/keldoc_center.py
@@ -52,9 +52,6 @@ class KeldocCenter:
             try:
                 cabinet_req = self.client.get(cabinet_url)
                 cabinet_req.raise_for_status()
-            except httpx.TimeoutException as hex:
-                logger.warning(f"Keldoc request timed out for center: {self.base_url} (vaccine cabinets)")
-                continue
             except httpx.HTTPStatusError as hex:
                 logger.warning(
                     f"Keldoc request returned error {hex.response.status_code} "
@@ -78,9 +75,6 @@ class KeldocCenter:
         try:
             resource = self.client.get(API_KELDOC_CENTER, params=self.resource_params)
             resource.raise_for_status()
-        except httpx.TimeoutException as hex:
-            logger.warning(f"Keldoc request timed out for center: {self.base_url} (center info)")
-            return False
         except httpx.HTTPStatusError as hex:
             logger.warning(
                 f"Keldoc request returned error {hex.response.status_code} "
@@ -105,9 +99,6 @@ class KeldocCenter:
         try:
             rq = self.client.get(self.base_url)
             rq.raise_for_status()
-        except httpx.TimeoutException as hex:
-            logger.warning(f"Keldoc request timed out for center: {self.base_url} (resource)")
-            return False
         except httpx.HTTPStatusError as hex:
             logger.warning(
                 f"Keldoc request returned error {hex.response.status_code} " f"for center: {self.base_url} (resource)"
@@ -183,12 +174,14 @@ class KeldocCenter:
                 f" calendar_params: {calendar_params}"
             )
             return timetable, run
+
         except httpx.HTTPStatusError as hex:
             logger.warning(
                 f"Keldoc request returned error {hex.response.status_code} "
                 f"for center: {self.base_url} (calendar request)"
             )
             return timetable, run
+
         except (httpx.RemoteProtocolError, httpx.ConnectError) as hex:
             logger.warning(f"Keldoc raise error {hex} for center: {self.base_url} (calendar request)")
             return timetable, run

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(
         "unidecode==1.2.0",
         "jsonschema==3.2.0",
         "pydantic==1.8.2",
+        "diskcache==5.2.1"
     ],
 )

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -54,7 +54,7 @@ def test_calls_default_off_behaviour ():
     def on_func (*args, **kwargs):
         raise Exception("some error")
 
-    breaker = CircuitBreaker(on=on_func, name="test name", trigger_count=1)
+    breaker = CircuitBreaker(on=on_func, name="test name", trigger=1)
     actual = None
 
     # When
@@ -82,7 +82,7 @@ def test_calls_off_function_with_args ():
     def on_func (*args, **kwargs):
         raise Exception("SomeError")
 
-    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=1)
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger=1)
 
     # When
     ignore_exception(lambda: breaker(8, 6, 'Hey', salut="bonjour"))
@@ -109,7 +109,7 @@ def test_calls_on_function_again ():
             raise Exception('Some Error')
         return 'ON'
 
-    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=1)
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger=1)
 
     # When
     ignore_exception(lambda: breaker())
@@ -130,7 +130,7 @@ def test_calls_on_function_again ():
     assert on_count == 2
     assert off_count == 10
 
-def test_calls_off_after_trigger_count ():
+def test_calls_off_after_trigger ():
     # Given
     off_count = 0
     on_count = 0
@@ -146,7 +146,7 @@ def test_calls_off_after_trigger_count ():
             raise Exception('Some Error')
         return 'ON'
 
-    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=3, release_count=5)
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger=3, release=5)
 
     # When
     ignore_exception(lambda: breaker()) # fail
@@ -172,7 +172,7 @@ def test_calls_off_after_trigger_count ():
     assert off_count == 10
     assert actual == "ON"
 
-def test_calls_off_after_soft_trigger_count ():
+def test_calls_off_after_soft_trigger ():
     # Given
     off_count = 0
     on_count = 0
@@ -189,7 +189,7 @@ def test_calls_off_after_soft_trigger_count ():
         else:
             raise Exception('Some Error')
 
-    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=3, release_count=5)
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger=3, release=5)
 
     # When
     ignore_exception(lambda: breaker()) # ON fail

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,218 @@
+import pytest
+from scraper.circuit_breaker import CircuitBreaker, CircuitBreakerOffException
+
+def noop():
+    pass
+def true():
+    return True
+def false():
+    return False
+
+def test_calls_on_function ():
+    # Given
+    on_count = 0
+    def on_func ():
+        nonlocal on_count
+        on_count = on_count +1
+
+    breaker = CircuitBreaker(on=on_func, off=noop)
+    # When
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+
+    # Then
+    assert on_count == 5
+
+def test_calls_on_function_with_args ():
+    # Given
+    on_args = None
+    on_kwargs = None
+    ret = { "some": 'return value' }
+
+    def on_func (*args, **kwargs):
+        nonlocal on_args, on_kwargs, ret
+        on_args = args
+        on_kwargs = kwargs
+        return ret
+
+    breaker = CircuitBreaker(on=on_func, off=noop)
+
+    # When
+    actual = breaker(8, 6, 'Hey', salut="bonjour")
+
+    # Then
+    assert on_args == (8, 6, 'Hey')
+    assert on_kwargs == { 'salut': "bonjour" }
+    assert actual == ret
+
+def test_calls_default_off_behaviour ():
+    # Given
+    expected_error_msg = f"CircuitBreaker 'test name' is currently off"
+    def on_func (*args, **kwargs):
+        raise Exception("some error")
+
+    breaker = CircuitBreaker(on=on_func, name="test name", trigger_count=1)
+    actual = None
+
+    # When
+    ignore_exception(lambda: breaker())
+    try:
+        breaker()
+    except Exception as e:
+        actual = e
+
+    # Then
+    assert True == isinstance(actual, CircuitBreakerOffException)
+    assert actual.message == expected_error_msg
+
+def test_calls_off_function_with_args ():
+    # Given
+    off_args = None
+    off_kwargs = None
+
+    def off_func (*args, **kwargs):
+        nonlocal off_args, off_kwargs
+        off_args = args
+        off_kwargs = kwargs
+        return "OFF"
+
+    def on_func (*args, **kwargs):
+        raise Exception("SomeError")
+
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=1)
+
+    # When
+    ignore_exception(lambda: breaker(8, 6, 'Hey', salut="bonjour"))
+    actual = breaker(8, 6, 'Hey', salut="bonjour")
+
+    # Then
+    assert off_args == (8, 6, 'Hey')
+    assert off_kwargs == { 'salut': "bonjour" }
+    assert actual == "OFF"
+
+def test_calls_on_function_again ():
+    # Given
+    off_count = 0
+    on_count = 0
+
+    def off_func (*args, **kwargs):
+        nonlocal off_count
+        off_count += 1
+
+    def on_func (*args, **kwargs):
+        nonlocal on_count
+        on_count += 1
+        if on_count == 1:
+            raise Exception('Some Error')
+        return 'ON'
+
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=1)
+
+    # When
+    ignore_exception(lambda: breaker())
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    breaker()
+    actual = actual = breaker()
+
+    # Then
+    assert actual == "ON"
+    assert on_count == 2
+    assert off_count == 10
+
+def test_calls_off_after_trigger_count ():
+    # Given
+    off_count = 0
+    on_count = 0
+
+    def off_func (*args, **kwargs):
+        nonlocal off_count
+        off_count += 1
+
+    def on_func (*args, **kwargs):
+        nonlocal on_count
+        on_count += 1
+        if on_count <= 6:
+            raise Exception('Some Error')
+        return 'ON'
+
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=3, release_count=5)
+
+    # When
+    ignore_exception(lambda: breaker()) # fail
+    ignore_exception(lambda: breaker()) # fail
+    ignore_exception(lambda: breaker()) # fail
+    breaker() # pass
+    breaker() # pass
+    breaker() # pass
+    breaker() # pass
+    breaker() # pass
+    ignore_exception(lambda: breaker()) # fail
+    ignore_exception(lambda: breaker()) # fail
+    ignore_exception(lambda: breaker()) # fail
+    breaker() # pass
+    breaker() # pass
+    breaker() # pass
+    breaker() # pass
+    breaker() # pass
+    actual = breaker()
+
+    # Then
+    assert on_count == 7
+    assert off_count == 10
+    assert actual == "ON"
+
+def test_calls_off_after_soft_trigger_count ():
+    # Given
+    off_count = 0
+    on_count = 0
+
+    def off_func (*args, **kwargs):
+        nonlocal off_count
+        off_count += 1
+
+    def on_func (*args, **kwargs):
+        nonlocal on_count
+        on_count += 1
+        if (on_count % 3) == 0:
+            return 'ON'
+        else:
+            raise Exception('Some Error')
+
+    breaker = CircuitBreaker(on=on_func, off=off_func, trigger_count=3, release_count=5)
+
+    # When
+    ignore_exception(lambda: breaker()) # ON fail
+    ignore_exception(lambda: breaker()) # ON fail
+    breaker() # ON pass
+    ignore_exception(lambda: breaker()) # ON fail
+    ignore_exception(lambda: breaker()) # ON fail
+    breaker() # OFF pass
+    breaker() # OFF pass
+    breaker() # OFF pass
+    breaker() # OFF pass
+    breaker() # OFF pass
+    actual = breaker() # ON pass
+
+    # Then
+    assert on_count == 6
+    assert off_count == 5
+    assert actual == "ON"
+
+
+def ignore_exception (func):
+    try:
+        return func()
+    except Exception:
+        pass
+

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -106,10 +106,8 @@ def test_calls_off_function_with_args ():
 def breakable (*args, **kwargs):
     raise Exception("SomeError")
 
-def run(*args, **kwargs):
-    print(f"running {breakable}")
+def run():
     try:
-        time.sleep(random.random() / 10)
         breakable()
         return 'on'
     except CircuitBreakerOffException:
@@ -117,22 +115,20 @@ def run(*args, **kwargs):
     except Exception:
         return 'on'
 
-@pytest.mark.skip
 def test_breaks_accross_processes ():
     # Given
     breakable.clear()
 
     # When
     actual = None
-    with Pool(2) as pool:
-        actual = pool.map(run, range(9), 1)
+    with Pool(4) as pool:
+        actual = pool.map(run, range(15), 1)
 
     # Then
     times_on = [on for on in actual if on == "on"]
     times_off = [off for off in actual if off == "off"]
-    assert len(times_on) == 6
-    assert len(times_off) == 3
-    assert actual == ["on", "on", "on", "off", "off", "off", "on", "on", "on"]
+    assert len(times_on) == 9
+    assert len(times_off) == 6
 
 
 def test_calls_on_function_again ():

--- a/tests/test_keldoc.py
+++ b/tests/test_keldoc.py
@@ -18,6 +18,8 @@ from scraper.keldoc.keldoc_filters import (
 )
 from scraper.pattern.scraper_request import ScraperRequest
 
+fetch_slots.breaker_enabled(False)
+
 CENTER1_KELDOC = {
     "/api/patients/v2/clinics/2563/specialties/144/cabinets": "center1-cabinet",
     "/api/patients/v2/clinics/2563/specialties/144/cabinets/18780/motive_categories": "center1-cabinet-18780",


### PR DESCRIPTION
**Checklist**

- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Un peu en rapport avec #368 et #445 

J'ai appliqué le pattern [_Circuit Breaker_](https://blog.octo.com/circuit-breaker-un-pattern-pour-fiabiliser-vos-systemes-distribues-ou-microservices-partie-2/) (désolé pour le lien corporate, mais c'est mon premier résultat google) sur la fonction `fetch_slot` du module Keldoc.

Le principe est de comptabiliser les excecution "erronée" (ici, temps trop long) et de couper l'accès à ce chemin d'exécution complètement pour un certain temps (ici un certain nombre de tentatives).

Les nombres sont évidemment à ajuster. Un effet de bord "sympa" c'est que ça limite le nombre de processus qui sont effectivement en train de faire des appels à Keldoc à la valeur du paramètre `trigger`.

Les tests Sur Ma Machine™ montrent que c'est très dur de prendre plus de 4 minutes pour l'execution du scrape complet.