### PR TITLE
get_city():  Pattern improvement

### DIFF
--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -116,7 +116,7 @@ class departementUtils:
         if not address:
             return None
         # tmp debug
-        if search := re.search(r"(?<=\s\d{5}\s)(?P<com_nom>.*?)\s*$", address):
+        if search := re.search(r"\D+\d{5}\s+(?P<com_nom>.*\S)\s*$", address):
             return search.groupdict().get("com_nom")
         return None
 


### PR DESCRIPTION
- remove the useless lookbehind assertion (since there's a capture group to extract the city)
- reach the postal code position more quickly from the start of the string with `\D+`
- more flexible with spaces between the postal code and the city `\s` => `\s+`
- change the reluctant quantifier to a greedy one followed by a non-space character `.*?` => `.*\S` 

test: https://regex101.com/r/cMq1Oq/1

<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [ ] Fix #issue
- [ ] J'ai ajouté des tests (si nécessaire)
- [ ] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
