### PR TITLE
Allow doctolib center scrap to run on fake client

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -34,7 +34,7 @@ DEFAULT_CLIENT = httpx.Client()
 logger = get_logger()
 
 
-class DoctolibCenters:
+class DoctolibCenterScraper:
     def __init__(self, client: httpx.Client = DEFAULT_CLIENT):
         self._client = client
 
@@ -130,8 +130,8 @@ class DoctolibCenters:
 def fetch_department(department: str):
     if not DOCTOLIB_CONF.enabled:
         return None
-    doctolib_centers = DoctolibCenters()
-    return doctolib_centers.run_departement_scrap(department)
+    scraper = DoctolibCenterScraper()
+    return scraper.run_departement_scrap(department)
 
 
 def parse_doctolib_centers(page_limit=None) -> List[dict]:

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -68,7 +68,7 @@ class DoctolibCenterScraper:
 
         return centers
 
-    def parse_page_centers_departement(self, departement, page_id, liste_urls) -> Tuple[List[dict], bool]:
+    def parse_page_centers_departement(self, departement: str, page_id: int, liste_urls: list) -> Tuple[List[dict], bool]:
         try:
             r = self._client.get(
                 BASE_URL_DEPARTEMENT.format(doctolib_urlify(departement), page_id),

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -45,7 +45,7 @@ class DoctolibCenterScraper:
             raise Exception("No Value found for department {}, crashing")
         return centers_departements
 
-    def parse_pages_departement(self, departement):
+    def parse_pages_departement(self, departement: str) -> list:
         departement = doctolib_urlify(departement)
         page_id = 1
         page_has_centers = True

--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -1,21 +1,27 @@
 import multiprocessing
 
-from scraper.pattern.scraper_result import VACCINATION_CENTER
-from utils.vmd_config import get_conf_platform, get_conf_inputs
-from utils.vmd_utils import departementUtils, format_phone_number
+from utils.vmd_config import get_conf_platform
 from utils.vmd_logger import get_logger
 
 from scraper.doctolib.conf import DoctolibConf
 from scraper.doctolib.doctolib import DOCTOLIB_HEADERS
 from scraper.doctolib.doctolib_filters import is_vaccination_center
+from scraper.doctolib.doctolib_parsers import (
+    get_departements,
+    doctolib_urlify,
+    get_coordinates,
+    center_type,
+    parse_doctolib_business_hours,
+    parse_place,
+    parse_center_places,
+    parse_doctor,
+)
 
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 import requests
 import json
 from urllib import parse
 import requests
-import re
-from unidecode import unidecode
 
 DOCTOLIB_CONF = DoctolibConf(**get_conf_platform("doctolib"))
 SCRAPER_CONF = DOCTOLIB_CONF.center_scraper
@@ -54,18 +60,6 @@ def parse_doctolib_centers(page_limit=None) -> List[dict]:
             unique_center_urls.append(item.get("rdv_site_web"))
 
         return centers
-
-
-def get_departements():
-    import csv
-
-    # Guyane uses Maiia and does not have doctolib pages
-    NOT_INCLUDED_DEPARTEMENTS = ["Guyane"]
-    with open(get_conf_inputs().get("departements"), encoding="utf8", newline="\n") as csvfile:
-        reader = csv.DictReader(csvfile)
-        departements = [str(row["nom_departement"]) for row in reader]
-        [departements.remove(ndep) for ndep in NOT_INCLUDED_DEPARTEMENTS]
-        return departements
 
 
 def parse_pages_departement(departement):
@@ -121,11 +115,6 @@ def parse_page_centers_departement(departement, page_id, liste_urls) -> Tuple[Li
     return centers_page, False
 
 
-def doctolib_urlify(departement: str) -> str:
-    departement = re.sub(r"\s+|\W", "-", departement).lower()
-    return unidecode(departement)
-
-
 def center_from_doctor_dict(doctor_dict) -> Tuple[dict, bool]:
     liste_centres = []
     dict_infos_browse_page = parse_doctor(doctor_dict)
@@ -140,36 +129,6 @@ def center_from_doctor_dict(doctor_dict) -> Tuple[dict, bool]:
 
     stop = not doctor_dict["exact_match"]
     return liste_centres, stop
-
-
-def get_coordinates(doctor_dict):
-    longitude = doctor_dict["position"]["lng"]
-    latitude = doctor_dict["position"]["lat"]
-    if longitude:
-        longitude = float(longitude)
-    if latitude:
-        latitude = float(latitude)
-    return longitude, latitude
-
-
-def parse_doctor(doctor_dict: Dict) -> Dict:
-    nom = doctor_dict["name_with_title"]
-    sub_addresse = doctor_dict["address"]
-    ville = doctor_dict["city"]
-    code_postal = doctor_dict["zipcode"].replace(" ", "").strip()
-    addresse = f"{sub_addresse}, {code_postal} {ville}"
-    url_path = doctor_dict["link"]
-    _type = center_type(url_path, nom)
-    longitude, latitude = get_coordinates(doctor_dict)
-    return {
-        "nom": nom,
-        "ville": ville,
-        "address": addresse,
-        "long_coor1": longitude,
-        "lat_coor1": latitude,
-        "type": _type,
-        "com_insee": departementUtils.cp_to_insee(code_postal),
-    }
 
 
 def get_dict_infos_center_page(url_path: str) -> dict:
@@ -187,96 +146,6 @@ def get_dict_infos_center_page(url_path: str) -> dict:
         return []
 
     return parse_center_places(output)
-
-
-def parse_center_places(center_output: Dict) -> List[Dict]:
-    places = center_output.get("places", {})
-    gid = "d{0}".format(center_output.get("profile", {}).get("id", ""))
-    extracted_visit_motives = [vm.get("name") for vm in center_output.get("visit_motives", [])]
-
-    liste_infos_page = []
-    for place in places:
-        infos_page = parse_place(place)
-        infos_page["gid"] = gid
-        infos_page["visit_motives"] = extracted_visit_motives
-        infos_page["booking"] = center_output
-        liste_infos_page.append(infos_page)
-
-    # Returns a list with data for each place
-    return liste_infos_page
-
-
-def parse_place(place: Dict) -> Dict:
-    infos_page = {}
-    # Parse place location
-    infos_page["place_id"] = place["id"]
-    infos_page["address"] = place["full_address"]
-    infos_page["ville"] = place["city"]
-    infos_page["long_coor1"] = place.get("longitude")
-    infos_page["lat_coor1"] = place.get("latitude")
-    infos_page["com_insee"] = departementUtils.cp_to_insee(place["zipcode"].replace(" ", "").strip())
-    # Parse landline number
-    if place.get("landline_number"):
-        phone_number = place.get("landline_number")
-    else:
-        phone_number = place.get("phone_number")
-    if phone_number:
-        infos_page["phone_number"] = format_phone_number(phone_number)
-
-    infos_page["business_hours"] = parse_doctolib_business_hours(place)
-    return infos_page
-
-
-def parse_doctolib_business_hours(place) -> dict:
-    # Opening hours
-    business_hours = dict()
-    if not place["opening_hours"]:
-        return None
-
-    for opening_hour in place["opening_hours"]:
-        format_hours = ""
-        key_name = SCRAPER_CONF.business_days[opening_hour["day"] - 1]
-        if not opening_hour.get("enabled", False):
-            business_hours[key_name] = None
-            continue
-        for range in opening_hour["ranges"]:
-            if len(format_hours) > 0:
-                format_hours += ", "
-            format_hours += f"{range[0]}-{range[1]}"
-        business_hours[key_name] = format_hours
-
-    return business_hours
-
-
-def center_type(url_path: str, nom: str) -> str:
-    for key in SCRAPER_CONF.center_types:
-        if key in nom.lower() or key in url_path:
-            return SCRAPER_CONF.center_types[key]
-    return SCRAPER_CONF.center_types.get("*", VACCINATION_CENTER)
-
-
-def center_reducer(center: dict) -> dict:
-    """This function should be used to remove fields that are irrelevant to the front,
-    such as fields used to filter centers during scraping process.
-    Removes following fields : visit_motives
-
-    Parameters
-    ----------
-    center_dict : "Center" dict
-        Center dict, output by the doctolib_center_scrap.center_from_doctor_dict
-
-    Returns
-    ----------
-    center dict, without irrelevant fields to the front
-
-    Example
-    ----------
-    >>> center_reducer({'gid': 'd257554', 'visit_motives': ['1re injection vaccin COVID-19 (Pfizer-BioNTech)', '2de injection vaccin COVID-19 (Pfizer-BioNTech)', '1re injection vaccin COVID-19 (Moderna)', '2de injection vaccin COVID-19 (Moderna)']})
-    {'gid': 'd257554'}
-    """
-    center.pop("visit_motives", "place_id")
-
-    return center
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scraper/doctolib/doctolib_parsers.py
+++ b/scraper/doctolib/doctolib_parsers.py
@@ -85,24 +85,17 @@ def parse_center_places(center_output: Dict) -> List[Dict]:
 
 
 def parse_place(place: Dict) -> Dict:
-    infos_page = {}
-    # Parse place location
-    infos_page["place_id"] = place["id"]
-    infos_page["address"] = place["full_address"]
-    infos_page["ville"] = place["city"]
-    infos_page["long_coor1"] = place.get("longitude")
-    infos_page["lat_coor1"] = place.get("latitude")
-    infos_page["com_insee"] = departementUtils.cp_to_insee(place["zipcode"].replace(" ", "").strip())
-    # Parse landline number
-    if place.get("landline_number"):
-        phone_number = place.get("landline_number")
-    else:
-        phone_number = place.get("phone_number")
-    if phone_number:
-        infos_page["phone_number"] = format_phone_number(phone_number)
-
-    infos_page["business_hours"] = parse_doctolib_business_hours(place)
-    return infos_page
+    phone_number =  place.get("landline_number", place.get("phone_number"))
+    return {
+      "place_id": place["id"],
+      "address": place["full_address"],
+      "ville": place["city"],
+      "long_coor1": place.get("longitude"),
+      "lat_coor1": place.get("latitude"),
+      "com_insee": departementUtils.cp_to_insee(place["zipcode"].replace(" ", "").strip()),
+      "phone_number": format_phone_number(phone_number) if phone_number else None,
+      "business_hours": parse_doctolib_business_hours(place),
+    }
 
 
 def parse_doctolib_business_hours(place: dict) -> Optional[dict]:

--- a/scraper/doctolib/doctolib_parsers.py
+++ b/scraper/doctolib/doctolib_parsers.py
@@ -105,7 +105,7 @@ def parse_place(place: Dict) -> Dict:
     return infos_page
 
 
-def parse_doctolib_business_hours(place) -> dict:
+def parse_doctolib_business_hours(place: dict) -> Optional[dict]:
     # Opening hours
     business_hours = dict()
     if not place["opening_hours"]:

--- a/scraper/doctolib/doctolib_parsers.py
+++ b/scraper/doctolib/doctolib_parsers.py
@@ -1,0 +1,150 @@
+import re
+
+from typing import Dict, List
+from unidecode import unidecode
+
+from scraper.doctolib.conf import DoctolibConf
+from scraper.pattern.scraper_result import VACCINATION_CENTER
+from utils.vmd_config import get_conf_platform, get_conf_inputs
+from utils.vmd_utils import departementUtils, format_phone_number
+
+
+DOCTOLIB_CONF = DoctolibConf(**get_conf_platform("doctolib"))
+SCRAPER_CONF = DOCTOLIB_CONF.center_scraper
+
+
+def get_departements():
+    import csv
+
+    # Guyane uses Maiia and does not have doctolib pages
+    NOT_INCLUDED_DEPARTEMENTS = ["Guyane"]
+    with open(get_conf_inputs().get("departements"), encoding="utf8", newline="\n") as csvfile:
+        reader = csv.DictReader(csvfile)
+        departements = [str(row["nom_departement"]) for row in reader]
+        [departements.remove(ndep) for ndep in NOT_INCLUDED_DEPARTEMENTS]
+        return departements
+
+
+def doctolib_urlify(departement: str) -> str:
+    departement = re.sub(r"\s+|\W", "-", departement).lower()
+    return unidecode(departement)
+
+
+def get_coordinates(doctor_dict: Dict):
+    longitude = doctor_dict["position"]["lng"]
+    latitude = doctor_dict["position"]["lat"]
+    if longitude:
+        longitude = float(longitude)
+    if latitude:
+        latitude = float(latitude)
+    return longitude, latitude
+
+
+def center_type(url_path: str, nom: str) -> str:
+    for key in SCRAPER_CONF.center_types:
+        if key in nom.lower() or key in url_path:
+            return SCRAPER_CONF.center_types[key]
+    return SCRAPER_CONF.center_types.get("*", VACCINATION_CENTER)
+
+
+def parse_doctor(doctor_dict: Dict) -> Dict:
+    nom = doctor_dict["name_with_title"]
+    sub_addresse = doctor_dict["address"]
+    ville = doctor_dict["city"]
+    code_postal = doctor_dict["zipcode"].replace(" ", "").strip()
+    addresse = f"{sub_addresse}, {code_postal} {ville}"
+    url_path = doctor_dict["link"]
+    _type = center_type(url_path, nom)
+    longitude, latitude = get_coordinates(doctor_dict)
+    return {
+        "nom": nom,
+        "ville": ville,
+        "address": addresse,
+        "long_coor1": longitude,
+        "lat_coor1": latitude,
+        "type": _type,
+        "com_insee": departementUtils.cp_to_insee(code_postal),
+    }
+
+
+def parse_center_places(center_output: Dict) -> List[Dict]:
+    places = center_output.get("places", {})
+    gid = "d{0}".format(center_output.get("profile", {}).get("id", ""))
+    extracted_visit_motives = [vm.get("name") for vm in center_output.get("visit_motives", [])]
+
+    liste_infos_page = []
+    for place in places:
+        infos_page = parse_place(place)
+        infos_page["gid"] = gid
+        infos_page["visit_motives"] = extracted_visit_motives
+        infos_page["booking"] = center_output
+        liste_infos_page.append(infos_page)
+
+    # Returns a list with data for each place
+    return liste_infos_page
+
+
+def parse_place(place: Dict) -> Dict:
+    infos_page = {}
+    # Parse place location
+    infos_page["place_id"] = place["id"]
+    infos_page["address"] = place["full_address"]
+    infos_page["ville"] = place["city"]
+    infos_page["long_coor1"] = place.get("longitude")
+    infos_page["lat_coor1"] = place.get("latitude")
+    infos_page["com_insee"] = departementUtils.cp_to_insee(place["zipcode"].replace(" ", "").strip())
+    # Parse landline number
+    if place.get("landline_number"):
+        phone_number = place.get("landline_number")
+    else:
+        phone_number = place.get("phone_number")
+    if phone_number:
+        infos_page["phone_number"] = format_phone_number(phone_number)
+
+    infos_page["business_hours"] = parse_doctolib_business_hours(place)
+    return infos_page
+
+
+def parse_doctolib_business_hours(place) -> dict:
+    # Opening hours
+    business_hours = dict()
+    if not place["opening_hours"]:
+        return None
+
+    for opening_hour in place["opening_hours"]:
+        format_hours = ""
+        key_name = SCRAPER_CONF.business_days[opening_hour["day"] - 1]
+        if not opening_hour.get("enabled", False):
+            business_hours[key_name] = None
+            continue
+        for range in opening_hour["ranges"]:
+            if len(format_hours) > 0:
+                format_hours += ", "
+            format_hours += f"{range[0]}-{range[1]}"
+        business_hours[key_name] = format_hours
+
+    return business_hours
+
+
+def center_reducer(center: dict) -> dict:
+    """This function should be used to remove fields that are irrelevant to the front,
+    such as fields used to filter centers during scraping process.
+    Removes following fields : visit_motives
+
+    Parameters
+    ----------
+    center_dict : "Center" dict
+        Center dict, output by the doctolib_center_scrap.center_from_doctor_dict
+
+    Returns
+    ----------
+    center dict, without irrelevant fields to the front
+
+    Example
+    ----------
+    >>> center_reducer({'gid': 'd257554', 'visit_motives': ['1re injection vaccin COVID-19 (Pfizer-BioNTech)', '2de injection vaccin COVID-19 (Pfizer-BioNTech)', '1re injection vaccin COVID-19 (Moderna)', '2de injection vaccin COVID-19 (Moderna)']})
+    {'gid': 'd257554'}
+    """
+    center.pop("visit_motives", "place_id")
+
+    return center

--- a/scraper/doctolib/doctolib_parsers.py
+++ b/scraper/doctolib/doctolib_parsers.py
@@ -1,6 +1,6 @@
 import re
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 from unidecode import unidecode
 
 from scraper.doctolib.conf import DoctolibConf
@@ -85,16 +85,16 @@ def parse_center_places(center_output: Dict) -> List[Dict]:
 
 
 def parse_place(place: Dict) -> Dict:
-    phone_number =  place.get("landline_number", place.get("phone_number"))
+    phone_number = place.get("landline_number", place.get("phone_number"))
     return {
-      "place_id": place["id"],
-      "address": place["full_address"],
-      "ville": place["city"],
-      "long_coor1": place.get("longitude"),
-      "lat_coor1": place.get("latitude"),
-      "com_insee": departementUtils.cp_to_insee(place["zipcode"].replace(" ", "").strip()),
-      "phone_number": format_phone_number(phone_number) if phone_number else None,
-      "business_hours": parse_doctolib_business_hours(place),
+        "place_id": place["id"],
+        "address": place["full_address"],
+        "ville": place["city"],
+        "long_coor1": place.get("longitude"),
+        "lat_coor1": place.get("latitude"),
+        "com_insee": departementUtils.cp_to_insee(place["zipcode"].replace(" ", "").strip()),
+        "phone_number": format_phone_number(phone_number) if phone_number else None,
+        "business_hours": parse_doctolib_business_hours(place),
     }
 
 

--- a/tests/fixtures/doctolib/scrap-center-result.json
+++ b/tests/fixtures/doctolib/scrap-center-result.json
@@ -1,0 +1,938 @@
+[
+    {
+        "nom": "Pharmacie des écoles - Leadersanté - Villejuif",
+        "ville": "Les Lilas",
+        "address": "41 Avenue du Maréchal Juin, 93260 Les Lilas",
+        "long_coor1": 2.42283520000001,
+        "lat_coor1": 48.8788792,
+        "type": "drugstore",
+        "com_insee": "93045",
+        "place_id": "practice-37157",
+        "phone_number": "+33600000000",
+        "business_hours": {
+            "lundi": null,
+            "mardi": null,
+            "mercredi": null,
+            "jeudi": null,
+            "vendredi": null,
+            "samedi": null,
+            "dimanche": null
+        },
+        "gid": "d1",
+        "visit_motives": [
+            "Consultation de suivi spécialiste",
+            "Première consultation de neurochirurgie"
+        ],
+        "booking": {
+            "profile": {
+                "id": 1,
+                "name_with_title": "Hopital test"
+            },
+            "visit_motives": [
+                {
+                    "name": "Consultation de suivi spécialiste"
+                },
+                {
+                    "name": "Première consultation de neurochirurgie"
+                }
+            ],
+            "places": [
+                {
+                    "id": "practice-37157",
+                    "latitude": 48.8788792,
+                    "longitude": 2.42283520000001,
+                    "phone_number": "06 00 00 00 00",
+                    "full_address": "41 Avenue du Maréchal Juin, 93260 Les Lilas",
+                    "city": "Les Lilas",
+                    "zipcode": "93260",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Clinique des Lilas "
+                },
+                {
+                    "id": "practice-86656",
+                    "latitude": 48.8814861,
+                    "longitude": 2.27230770000006,
+                    "landline_number": "06 38 95 25 53",
+                    "full_address": "11 Rue d'Orléans, 92200 Neuilly-sur-Seine",
+                    "city": "Neuilly-sur-Seine",
+                    "zipcode": "92200",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Cabinet Neuilly"
+                }
+            ],
+            "doctors": [
+                {
+                    "address": "22b Rue Jean Jaurès",
+                    "city": "Villejuif",
+                    "zipcode": "94800",
+                    "link": "/pharmacie/villejuif/pharmacie-des-ecoles",
+                    "name_with_title": "Pharmacie des écoles - Leadersanté - Villejuif",
+                    "position": {
+                        "lat": 48.7951181,
+                        "lng": 2.3662778
+                    },
+                    "place_id": null,
+                    "exact_match": true
+                },
+                {
+                    "address": "96 Avenue Jean Jaurès",
+                    "city": "Le Petit-Quevilly",
+                    "zipcode": "76140",
+                    "link": "/vaccinodrome/le-petit-quevilly/dubois",
+                    "name_with_title": "Vaccinodrome Jean Jaurès",
+                    "position": {
+                        "lat": 49.4269181,
+                        "lng": 1.0627287
+                    },
+                    "place_id": 1,
+                    "exact_match": true
+                }
+            ]
+        },
+        "rdv_site_web": "https://www.doctolib.fr/pharmacie/villejuif/pharmacie-des-ecoles?pid=practice-37157"
+    },
+    {
+        "nom": "Pharmacie des écoles - Leadersanté - Villejuif",
+        "ville": "Neuilly-sur-Seine",
+        "address": "11 Rue d'Orléans, 92200 Neuilly-sur-Seine",
+        "long_coor1": 2.27230770000006,
+        "lat_coor1": 48.8814861,
+        "type": "drugstore",
+        "com_insee": "92051",
+        "place_id": "practice-86656",
+        "phone_number": "+33638952553",
+        "business_hours": {
+            "lundi": null,
+            "mardi": null,
+            "mercredi": null,
+            "jeudi": null,
+            "vendredi": null,
+            "samedi": null,
+            "dimanche": null
+        },
+        "gid": "d1",
+        "visit_motives": [
+            "Consultation de suivi spécialiste",
+            "Première consultation de neurochirurgie"
+        ],
+        "booking": {
+            "profile": {
+                "id": 1,
+                "name_with_title": "Hopital test"
+            },
+            "visit_motives": [
+                {
+                    "name": "Consultation de suivi spécialiste"
+                },
+                {
+                    "name": "Première consultation de neurochirurgie"
+                }
+            ],
+            "places": [
+                {
+                    "id": "practice-37157",
+                    "latitude": 48.8788792,
+                    "longitude": 2.42283520000001,
+                    "phone_number": "06 00 00 00 00",
+                    "full_address": "41 Avenue du Maréchal Juin, 93260 Les Lilas",
+                    "city": "Les Lilas",
+                    "zipcode": "93260",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Clinique des Lilas "
+                },
+                {
+                    "id": "practice-86656",
+                    "latitude": 48.8814861,
+                    "longitude": 2.27230770000006,
+                    "landline_number": "06 38 95 25 53",
+                    "full_address": "11 Rue d'Orléans, 92200 Neuilly-sur-Seine",
+                    "city": "Neuilly-sur-Seine",
+                    "zipcode": "92200",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Cabinet Neuilly"
+                }
+            ],
+            "doctors": [
+                {
+                    "address": "22b Rue Jean Jaurès",
+                    "city": "Villejuif",
+                    "zipcode": "94800",
+                    "link": "/pharmacie/villejuif/pharmacie-des-ecoles",
+                    "name_with_title": "Pharmacie des écoles - Leadersanté - Villejuif",
+                    "position": {
+                        "lat": 48.7951181,
+                        "lng": 2.3662778
+                    },
+                    "place_id": null,
+                    "exact_match": true
+                },
+                {
+                    "address": "96 Avenue Jean Jaurès",
+                    "city": "Le Petit-Quevilly",
+                    "zipcode": "76140",
+                    "link": "/vaccinodrome/le-petit-quevilly/dubois",
+                    "name_with_title": "Vaccinodrome Jean Jaurès",
+                    "position": {
+                        "lat": 49.4269181,
+                        "lng": 1.0627287
+                    },
+                    "place_id": 1,
+                    "exact_match": true
+                }
+            ]
+        },
+        "rdv_site_web": "https://www.doctolib.fr/pharmacie/villejuif/pharmacie-des-ecoles?pid=practice-86656"
+    },
+    {
+        "nom": "Vaccinodrome Jean Jaurès",
+        "ville": "Les Lilas",
+        "address": "41 Avenue du Maréchal Juin, 93260 Les Lilas",
+        "long_coor1": 2.42283520000001,
+        "lat_coor1": 48.8788792,
+        "type": "vaccination-center",
+        "com_insee": "93045",
+        "place_id": "practice-37157",
+        "phone_number": "+33600000000",
+        "business_hours": {
+            "lundi": null,
+            "mardi": null,
+            "mercredi": null,
+            "jeudi": null,
+            "vendredi": null,
+            "samedi": null,
+            "dimanche": null
+        },
+        "gid": "d1",
+        "visit_motives": [
+            "Consultation de suivi spécialiste",
+            "Première consultation de neurochirurgie"
+        ],
+        "booking": {
+            "profile": {
+                "id": 1,
+                "name_with_title": "Hopital test"
+            },
+            "visit_motives": [
+                {
+                    "name": "Consultation de suivi spécialiste"
+                },
+                {
+                    "name": "Première consultation de neurochirurgie"
+                }
+            ],
+            "places": [
+                {
+                    "id": "practice-37157",
+                    "latitude": 48.8788792,
+                    "longitude": 2.42283520000001,
+                    "phone_number": "06 00 00 00 00",
+                    "full_address": "41 Avenue du Maréchal Juin, 93260 Les Lilas",
+                    "city": "Les Lilas",
+                    "zipcode": "93260",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Clinique des Lilas "
+                },
+                {
+                    "id": "practice-86656",
+                    "latitude": 48.8814861,
+                    "longitude": 2.27230770000006,
+                    "landline_number": "06 38 95 25 53",
+                    "full_address": "11 Rue d'Orléans, 92200 Neuilly-sur-Seine",
+                    "city": "Neuilly-sur-Seine",
+                    "zipcode": "92200",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Cabinet Neuilly"
+                }
+            ],
+            "doctors": [
+                {
+                    "address": "22b Rue Jean Jaurès",
+                    "city": "Villejuif",
+                    "zipcode": "94800",
+                    "link": "/pharmacie/villejuif/pharmacie-des-ecoles",
+                    "name_with_title": "Pharmacie des écoles - Leadersanté - Villejuif",
+                    "position": {
+                        "lat": 48.7951181,
+                        "lng": 2.3662778
+                    },
+                    "place_id": null,
+                    "exact_match": true
+                },
+                {
+                    "address": "96 Avenue Jean Jaurès",
+                    "city": "Le Petit-Quevilly",
+                    "zipcode": "76140",
+                    "link": "/vaccinodrome/le-petit-quevilly/dubois",
+                    "name_with_title": "Vaccinodrome Jean Jaurès",
+                    "position": {
+                        "lat": 49.4269181,
+                        "lng": 1.0627287
+                    },
+                    "place_id": 1,
+                    "exact_match": true
+                }
+            ]
+        },
+        "rdv_site_web": "https://www.doctolib.fr/vaccinodrome/le-petit-quevilly/dubois?pid=practice-37157"
+    },
+    {
+        "nom": "Vaccinodrome Jean Jaurès",
+        "ville": "Neuilly-sur-Seine",
+        "address": "11 Rue d'Orléans, 92200 Neuilly-sur-Seine",
+        "long_coor1": 2.27230770000006,
+        "lat_coor1": 48.8814861,
+        "type": "vaccination-center",
+        "com_insee": "92051",
+        "place_id": "practice-86656",
+        "phone_number": "+33638952553",
+        "business_hours": {
+            "lundi": null,
+            "mardi": null,
+            "mercredi": null,
+            "jeudi": null,
+            "vendredi": null,
+            "samedi": null,
+            "dimanche": null
+        },
+        "gid": "d1",
+        "visit_motives": [
+            "Consultation de suivi spécialiste",
+            "Première consultation de neurochirurgie"
+        ],
+        "booking": {
+            "profile": {
+                "id": 1,
+                "name_with_title": "Hopital test"
+            },
+            "visit_motives": [
+                {
+                    "name": "Consultation de suivi spécialiste"
+                },
+                {
+                    "name": "Première consultation de neurochirurgie"
+                }
+            ],
+            "places": [
+                {
+                    "id": "practice-37157",
+                    "latitude": 48.8788792,
+                    "longitude": 2.42283520000001,
+                    "phone_number": "06 00 00 00 00",
+                    "full_address": "41 Avenue du Maréchal Juin, 93260 Les Lilas",
+                    "city": "Les Lilas",
+                    "zipcode": "93260",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Clinique des Lilas "
+                },
+                {
+                    "id": "practice-86656",
+                    "latitude": 48.8814861,
+                    "longitude": 2.27230770000006,
+                    "landline_number": "06 38 95 25 53",
+                    "full_address": "11 Rue d'Orléans, 92200 Neuilly-sur-Seine",
+                    "city": "Neuilly-sur-Seine",
+                    "zipcode": "92200",
+                    "opening_hours": [
+                        {
+                            "day": 1,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 2,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 3,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 4,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 5,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 6,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        },
+                        {
+                            "day": 0,
+                            "ranges": [
+                                [
+                                    "09:00",
+                                    "13:00"
+                                ]
+                            ],
+                            "enabled": false
+                        }
+                    ],
+                    "name": "Cabinet Neuilly"
+                }
+            ],
+            "doctors": [
+                {
+                    "address": "22b Rue Jean Jaurès",
+                    "city": "Villejuif",
+                    "zipcode": "94800",
+                    "link": "/pharmacie/villejuif/pharmacie-des-ecoles",
+                    "name_with_title": "Pharmacie des écoles - Leadersanté - Villejuif",
+                    "position": {
+                        "lat": 48.7951181,
+                        "lng": 2.3662778
+                    },
+                    "place_id": null,
+                    "exact_match": true
+                },
+                {
+                    "address": "96 Avenue Jean Jaurès",
+                    "city": "Le Petit-Quevilly",
+                    "zipcode": "76140",
+                    "link": "/vaccinodrome/le-petit-quevilly/dubois",
+                    "name_with_title": "Vaccinodrome Jean Jaurès",
+                    "position": {
+                        "lat": 49.4269181,
+                        "lng": 1.0627287
+                    },
+                    "place_id": 1,
+                    "exact_match": true
+                }
+            ]
+        },
+        "rdv_site_web": "https://www.doctolib.fr/vaccinodrome/le-petit-quevilly/dubois?pid=practice-86656"
+    }
+]

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -1,4 +1,4 @@
-from scraper.doctolib.doctolib_center_scrap import (
+from scraper.doctolib.doctolib_parsers import (
     get_departements,
     doctolib_urlify,
     get_coordinates,
@@ -246,7 +246,7 @@ EXPECTED_PARSED_PAGES = [
 
 
 def test_parse_places():
-    with open("tests/fixtures/doctolib/booking-with-doctors.json", "r", encoding='utf8') as f:
+    with open("tests/fixtures/doctolib/booking-with-doctors.json", "r", encoding="utf8") as f:
         booking = json.load(f)
         assert parse_center_places(booking["data"]) == EXPECTED_PARSED_PAGES
 

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -8,7 +8,7 @@ from scraper.doctolib.doctolib_parsers import (
     parse_center_places,
     parse_doctor,
 )
-from scraper.doctolib.doctolib_center_scrap import DoctolibCenters
+from scraper.doctolib.doctolib_center_scrap import DoctolibCenterScraper
 
 import httpx
 import json
@@ -491,6 +491,6 @@ def test_doctolib_center_scrap():
         return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
 
     client = httpx.Client(transport=httpx.MockTransport(app))
-    centers = DoctolibCenters(client=client)
-    result = centers.run_departement_scrap("test")
+    scraper = DoctolibCenterScraper(client=client)
+    result = scraper.run_departement_scrap("test")
     assert result == json.loads(Path("tests/fixtures/doctolib/scrap-center-result.json").read_text())

--- a/tests/test_doctolib_scraper.py
+++ b/tests/test_doctolib_scraper.py
@@ -8,8 +8,11 @@ from scraper.doctolib.doctolib_parsers import (
     parse_center_places,
     parse_doctor,
 )
+from scraper.doctolib.doctolib_center_scrap import DoctolibCenters
 
+import httpx
 import json
+from pathlib import Path
 
 # -- Tests de l'API (offline) --
 from scraper.pattern.scraper_result import GENERAL_PRACTITIONER, DRUG_STORE, VACCINATION_CENTER
@@ -480,3 +483,14 @@ def test_centers_parsing(mock_get):
 
 #    mockedResponse = parse_pages_departement("indre")
 #    assert mockedResponse == expectedCentersPage
+
+
+def test_doctolib_center_scrap():
+    def app(request: httpx.Request) -> httpx.Response:
+        path = Path("tests", "fixtures", "doctolib", "booking-with-doctors.json")
+        return httpx.Response(200, json=json.loads(path.read_text(encoding="utf-8")))
+
+    client = httpx.Client(transport=httpx.MockTransport(app))
+    centers = DoctolibCenters(client=client)
+    result = centers.run_departement_scrap("test")
+    assert result == json.loads(Path("tests/fixtures/doctolib/scrap-center-result.json").read_text())


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [ ] Fix #issue
- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Refact de doctolib center scrap pour avoir une structure similaire au scraper principal de doctolib, qu'on peut faire tourner sur un mock dans les tests. 

<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
