### PR TITLE
Ajout Captain Pharma (Nanterre) Ordoclic à blocklist

### DIFF
--- a/data/input/centers_blocklist.json
+++ b/data/input/centers_blocklist.json
@@ -5,5 +5,9 @@
         "name": "Grande Pharmacie Marcadet",
         "url" : "https://partners.doctolib.fr/pharmacie/paris/grande-pharmacie-marcadet",
         "issue": "https://github.com/CovidTrackerFr/vitemadose/issues/319"
-    }]
+    },{
+         "name": "Captain Pharma",
+         "details": "La pharmacie est sur Doctolib et Ordoclic et ne veut pas apparaitre via Ordoclic (rdv tel uniquement) sur VMD",
+         "url": "https://app.ordoclic.fr/app/pharmacie/captain-pharma-nanterre"
+     }]
 }


### PR DESCRIPTION
La pharmacie est sur ordoclic et doctolib et ne veut pas être référencée via ordoclic.
