### PR TITLE
Ajout d'helper pour API Adresse

### DIFF
--- a/tests/test_geo_api.py
+++ b/tests/test_geo_api.py
@@ -16,12 +16,10 @@ def test_get_location_from_address():
     address: str = "389 Avenue Maréchal de Lattre de Tassigny"
     inseecode: str = "71270"  # Varennes-lès-Mâcon
     zipcode: str = "71000"
-    coordinates: Coordinates = Coordinates(4.8405438, 46.3165338)
 
     assert get_location_from_address(address) != location
     assert get_location_from_address(address, zipcode=zipcode) == location
     assert get_location_from_address(address, inseecode=inseecode) == location
-    assert get_location_from_address(address, coordinates=coordinates) == location
 
 
 def test_get_location_from_coordinates():

--- a/tests/test_geo_api.py
+++ b/tests/test_geo_api.py
@@ -59,8 +59,22 @@ def test_get_location_from_address():
     assert get_location_from_address(address, zipcode=cedexcode) == None  # API Adresse does not handle CEDEX codes
     assert get_location_from_address(address, inseecode=inseecode) == location3
 
+    # Check cache mechanism
+    get_location_from_address.cache_clear()
+    get_location_from_address(address)
+    get_location_from_address(address)
+    assert get_location_from_address.cache_info().hits == 1
+    assert get_location_from_address.cache_info().misses == 1
+
 
 def test_get_location_from_coordinates():
     coordinates: Coordinates = Coordinates(4.8405438, 46.3165338)
 
     assert get_location_from_coordinates(coordinates) == location1
+
+    # Check cache mechanism
+    get_location_from_coordinates.cache_clear()
+    get_location_from_coordinates(coordinates)
+    get_location_from_coordinates(coordinates)
+    assert get_location_from_coordinates.cache_info().hits == 1
+    assert get_location_from_coordinates.cache_info().misses == 1

--- a/tests/test_geo_api.py
+++ b/tests/test_geo_api.py
@@ -1,6 +1,6 @@
 from utils.vmd_geo_api import get_location_from_address, get_location_from_coordinates, Location, Coordinates
 
-location: Location = {
+location1: Location = {
     "full_address": "389 Av Mal de Lattre de Tassigny 71000 Mâcon",
     "number_street": "389 Av Mal de Lattre de Tassigny",
     "com_name": "Mâcon",
@@ -12,17 +12,55 @@ location: Location = {
 }
 
 
+location2: Location = {
+    "full_address": "4 Rue des Hibiscus 97200 Fort-de-France",
+    "number_street": "4 Rue des Hibiscus",
+    "com_name": "Fort-de-France",
+    "com_zipcode": "97200",
+    "com_insee": "97209",
+    "departement": "972",
+    "longitude": -61.078206,
+    "latitude": 14.611228,
+}
+
+
+location3: Location = {
+    "full_address": "Rue du Grand But 59000 Lille",
+    "number_street": "Rue du Grand But",
+    "com_name": "Lille",
+    "com_zipcode": "59000",
+    "com_insee": "59350",
+    "departement": "59",
+    "longitude": 2.974314,
+    "latitude": 50.649992,
+}
+
+
 def test_get_location_from_address():
+    # Common address
     address: str = "389 Avenue Maréchal de Lattre de Tassigny"
     inseecode: str = "71270"  # Varennes-lès-Mâcon
     zipcode: str = "71000"
 
-    assert get_location_from_address(address) != location
-    assert get_location_from_address(address, zipcode=zipcode) == location
-    assert get_location_from_address(address, inseecode=inseecode) == location
+    assert get_location_from_address(address) != location1  # Too generic, can't find with more input
+    assert get_location_from_address(address, zipcode=zipcode) == location1
+    assert get_location_from_address(address, inseecode=inseecode) == location1
+
+    # Specific address, in DOM-TOM
+    address: str = "4 rue des Hibiscus\n97200 Fort-de-France"
+    assert get_location_from_address(address) == location2
+
+    # Specific address with CEDEX code
+    address: str = "Rue du Grand But - BP 249, 59462Cedex Lomme"
+    cedexcode: str = "59462"
+    inseecode: str = "59350"
+
+    assert get_location_from_address(address) == location3
+    assert get_location_from_address(address, zipcode=cedexcode) == None  # API Adresse does not handle CEDEX codes
+    assert get_location_from_address(address, inseecode=inseecode) == location3
 
 
 def test_get_location_from_coordinates():
     coordinates: Coordinates = Coordinates(4.8405438, 46.3165338)
 
-    assert get_location_from_coordinates(coordinates) == location
+    assert get_location_from_coordinates(coordinates) == location1

--- a/tests/test_geo_api.py
+++ b/tests/test_geo_api.py
@@ -1,0 +1,30 @@
+from utils.vmd_geo_api import get_location_from_address, get_location_from_coordinates, Location, Coordinates
+
+location: Location = {
+    "full_address": "389 Av Mal de Lattre de Tassigny 71000 Mâcon",
+    "number_street": "389 Av Mal de Lattre de Tassigny",
+    "com_name": "Mâcon",
+    "com_zipcode": "71000",
+    "com_insee": "71270",
+    "departement": "71",
+    "longitude": 4.839588,
+    "latitude": 46.315857,
+}
+
+
+def test_get_location_from_address():
+    address: str = "389 Avenue Maréchal de Lattre de Tassigny"
+    inseecode: str = "71270"  # Varennes-lès-Mâcon
+    zipcode: str = "71000"
+    coordinates: Coordinates = Coordinates(4.8405438, 46.3165338)
+
+    assert get_location_from_address(address) != location
+    assert get_location_from_address(address, zipcode=zipcode) == location
+    assert get_location_from_address(address, inseecode=inseecode) == location
+    assert get_location_from_address(address, coordinates=coordinates) == location
+
+
+def test_get_location_from_coordinates():
+    coordinates: Coordinates = Coordinates(4.8405438, 46.3165338)
+
+    assert get_location_from_coordinates(coordinates) == location

--- a/utils/vmd_geo_api.py
+++ b/utils/vmd_geo_api.py
@@ -1,0 +1,73 @@
+from typing import TypedDict, Optional, NamedTuple
+import requests
+from utils.vmd_logger import get_logger
+
+logger = get_logger()
+
+
+class Location(TypedDict):
+    full_address: str
+    number_street: str
+    com_name: str
+    com_zipcode: str
+    com_insee: str
+    departement: str
+    latitude: float
+    longitude: float
+
+
+class Coordinates(NamedTuple):
+    longitude: float
+    latitude: float
+
+
+def get_location_from_address(
+    address: str,
+    zipcode: Optional[str] = None,
+    inseecode: Optional[str] = None,
+    coordinates: Optional[Coordinates] = None,
+) -> Optional[Location]:
+    params = {"q": address, "limit": 1}
+
+    if zipcode:
+        params["postcode"] = zipcode
+    elif inseecode:
+        params["citycode"] = inseecode
+    elif coordinates:
+        params["lat"] = getattr(coordinates, "latitude")
+        params["lon"] = getattr(coordinates, "longitude")
+
+    r = requests.get("https://api-adresse.data.gouv.fr/search/", params=params)
+
+    return _parse_geojson(r.json())
+
+
+def get_location_from_coordinates(coordinates: Coordinates) -> Optional[Location]:
+    params = {"lon": getattr(coordinates, "longitude"), "lat": getattr(coordinates, "latitude")}
+
+    r = requests.get("https://api-adresse.data.gouv.fr/reverse/", params=params)
+
+    return _parse_geojson(r.json())
+
+
+def _parse_geojson(geojson: str) -> Location:
+    if not geojson["features"]:
+        return None
+
+    result = geojson["features"][0]
+    prop = result["properties"]
+    geometry = result["geometry"]
+
+    if prop["type"] != "housenumber":
+        logger.warning("GeoJSON imprecise, could not get a house number location.")
+
+    return {
+        "full_address": prop["label"],
+        "number_street": prop["name"],
+        "com_name": prop["city"],
+        "com_zipcode": prop["postcode"],
+        "com_insee": prop["citycode"],
+        "departement": prop["context"].split(",")[0],
+        "longitude": geometry["coordinates"][0],
+        "latitude": geometry["coordinates"][1],
+    }

--- a/utils/vmd_geo_api.py
+++ b/utils/vmd_geo_api.py
@@ -1,6 +1,7 @@
 from typing import TypedDict, Optional, NamedTuple
 import requests
 from utils.vmd_logger import get_logger
+from functools import lru_cache
 
 logger = get_logger()
 
@@ -21,6 +22,7 @@ class Coordinates(NamedTuple):
     latitude: float
 
 
+@lru_cache
 def get_location_from_address(
     address: str,
     zipcode: Optional[str] = None,
@@ -38,6 +40,7 @@ def get_location_from_address(
     return _parse_geojson(r.json())
 
 
+@lru_cache
 def get_location_from_coordinates(coordinates: Coordinates) -> Optional[Location]:
     params = {"lon": getattr(coordinates, "longitude"), "lat": getattr(coordinates, "latitude")}
 

--- a/utils/vmd_geo_api.py
+++ b/utils/vmd_geo_api.py
@@ -25,7 +25,6 @@ def get_location_from_address(
     address: str,
     zipcode: Optional[str] = None,
     inseecode: Optional[str] = None,
-    coordinates: Optional[Coordinates] = None,
 ) -> Optional[Location]:
     params = {"q": address, "limit": 1}
 
@@ -33,9 +32,6 @@ def get_location_from_address(
         params["postcode"] = zipcode
     elif inseecode:
         params["citycode"] = inseecode
-    elif coordinates:
-        params["lat"] = getattr(coordinates, "latitude")
-        params["lon"] = getattr(coordinates, "longitude")
 
     r = requests.get("https://api-adresse.data.gouv.fr/search/", params=params)
 


### PR DESCRIPTION
**Description**

Ajout de fonctions pour appeler les endpoints search/ and reverse/ de [API Adresse](https://geo.api.gouv.fr/adresse). C'est en prévision de l'ajout de Clikodoc, les adresses sont de mauvaises qualités (adresse avec code postal, adresse avec code postal et commune, adresse en majuscule). A fortiori, on pourrait utiliser ces appels pour toutes les plateformes, la limite est à 50 appels par secondes et IP. 

Il y a apparemment un soucis sur l'API search/ parce que l'aide à la localisation avec des coordonnées ne donnent pas de bons résultats (cf. le test qui échoue), je vais essayer de remonter le problème, dans le pire des cas, j'enlèverai cette option

