### PR TITLE
Installation de l'agent Datadog dans les runners gitlab

### DIFF
--- a/gitlab-runner/envs/terragrunt.hcl
+++ b/gitlab-runner/envs/terragrunt.hcl
@@ -18,4 +18,5 @@ inputs = {
   ovh_region = path_relative_to_include()
   gitlab_runner_token = get_env("GITLAB_RUNNER_TOKEN")
   flavor = "c2-7"
+  datadog_api_key = get_env("DD_API_KEY")
 }

--- a/gitlab-runner/modules/runner/main.tf
+++ b/gitlab-runner/modules/runner/main.tf
@@ -31,7 +31,7 @@ resource null_resource "register_runner" {
     user = "debian"
     gitlab_runner_token = var.gitlab_runner_token
     ovh_region = var.ovh_region
-    dd_api_key = var.datadog_api_key
+    datadog_api_key = var.datadog_api_key
   }
   connection {
     user = self.triggers.user
@@ -50,7 +50,7 @@ resource null_resource "register_runner" {
       "export GITLAB_RUNNER_TOKEN=${self.triggers.gitlab_runner_token}",
       "export RUNNER_LOCATION='OVH ${self.triggers.ovh_region} (num ${count.index})'",
       "export TAG_LIST='ovh,ovh-${self.triggers.ovh_region},${formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())}'",
-      "export DD_API_KEY=${self.trigger.datadog_api_key}",
+      "export DD_API_KEY=${self.triggers.datadog_api_key}",
       "export GITLAB_RUN_UNTAGGED=yes",
       "sudo -E bash /tmp/provision-${random_string.provision_name.id}.sh"
     ]

--- a/gitlab-runner/modules/runner/main.tf
+++ b/gitlab-runner/modules/runner/main.tf
@@ -31,6 +31,7 @@ resource null_resource "register_runner" {
     user = "debian"
     gitlab_runner_token = var.gitlab_runner_token
     ovh_region = var.ovh_region
+    dd_api_key = var.datadog_api_key
   }
   connection {
     user = self.triggers.user
@@ -49,6 +50,7 @@ resource null_resource "register_runner" {
       "export GITLAB_RUNNER_TOKEN=${self.triggers.gitlab_runner_token}",
       "export RUNNER_LOCATION='OVH ${self.triggers.ovh_region} (num ${count.index})'",
       "export TAG_LIST='ovh,ovh-${self.triggers.ovh_region},${formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())}'",
+      "export DD_API_KEY=${self.trigger.datadog_api_key}",
       "export GITLAB_RUN_UNTAGGED=yes",
       "sudo -E bash /tmp/provision-${random_string.provision_name.id}.sh"
     ]

--- a/gitlab-runner/modules/runner/provision.sh
+++ b/gitlab-runner/modules/runner/provision.sh
@@ -27,6 +27,9 @@ function main () {
   cartouche "Installing Gitlab Runner"
   install_gitlab_runner
 
+  cartouche "Installing Datadog Agent"
+  install_dd_agent
+
   cartouche "Register Gitlab Runner"
   register_gitlab_runner
 
@@ -40,6 +43,13 @@ function install_gitlab_runner () {
   apt-get install -y gitlab-runner
   gitlab-runner start
   adduser gitlab-runner docker
+}
+
+function install_dd_agent () {
+  export DD_AGENT_MAJOR_VERSION=7
+  export DD_API_KEY=${DD_API_KEY}
+  export DD_SITE="datadoghq.com"
+  bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)"
 }
 
 function register_gitlab_runner () {

--- a/gitlab-runner/modules/runner/variables.tf
+++ b/gitlab-runner/modules/runner/variables.tf
@@ -11,6 +11,10 @@ variable "gitlab_runner_token" {
   description = "Le registration token Gitlab"
   type = string
 }
+variable "datadog_api_key" {
+  description = "Clé d'API datadog"
+  type = string
+}
 variable "nb_instances" {
   description = "Le nombre de runners à lancer"
   type = number


### PR DESCRIPTION
La documentation de l'installation datadog de l'agent se trouve ici:
https://docs.datadoghq.com/getting_started/agent/

Le code est disponible ici 
https://s3.amazonaws.com/dd-agent/scripts/install_script.sh

Je suppose que `DD_API_KEY` est injecté à la main et peut être trouvé là https://app.datadoghq.com/account/settings#api. Il faut prendre la clé `GitLab Runner`.

D'autres PR pourront suivre pour la configuration de l'agent (collecte des logs, tags, etc.) pour l'instant j'essaye juste d'avoir un agent fonctionnel qui remonte des métriques. 