### PR TITLE
Ajustements pour la performance avec les Creneaux

### DIFF
--- a/scraper/export/export_v2.py
+++ b/scraper/export/export_v2.py
@@ -32,7 +32,6 @@ class JSONExporter:
     def export(self, creneaux: Iterator[Creneau]):
         count = 0
         for creneau in creneaux:
-            logger.debug(f"Got Creneau {creneau}")
             count += 1
             for resource in self.resources.values():
                 resource.on_creneau(creneau)

--- a/scraper/export/resource_centres.py
+++ b/scraper/export/resource_centres.py
@@ -26,7 +26,7 @@ class ResourceTousDepartements(Resource):
 
         centre = self.centres_disponibles[lieu.internal_id]
         centre["appointment_count"] += 1
-        centre["vaccine_type"] = sorted(list(set(centre["vaccine_type"] + [creneau.type_vaccin.value])))
+        centre["vaccine_type"][creneau.type_vaccin.value] = True
         if not centre["prochain_rdv"] or centre["prochain_rdv"] > creneau.horaire:
             centre["prochain_rdv"] = creneau.horaire
 
@@ -42,7 +42,7 @@ class ResourceTousDepartements(Resource):
             "type": lieu.lieu_type,
             "appointment_count": 0,
             "internal_id": lieu.internal_id,
-            "vaccine_type": [],
+            "vaccine_type": {},
             "appointment_schedules": [],
             "appointment_by_phone_only": False,
             "erreur": None,
@@ -63,13 +63,14 @@ class ResourceTousDepartements(Resource):
             "version": 1,
             "last_updated": self.now(tz=gettz()).replace(microsecond=0).isoformat(),
             "centres_disponibles": sorted([self.centre_asdict(c) for c in self.centres_disponibles.values()], key=sort_center),
-            "centres_indisponibles": list(self.centres_indisponibles.values()),
+            "centres_indisponibles": [self.centre_asdict(c) for c in self.centres_indisponibles.values()]
         }
 
     def centre_asdict(self, centre):
         return {
             **centre,
-            'prochain_rdv': centre['prochain_rdv'].replace(microsecond=0).isoformat()
+            'prochain_rdv': centre['prochain_rdv'].replace(microsecond=0).isoformat() if centre['prochain_rdv'] else None,
+            'vaccine_type': sorted(list(centre['vaccine_type'].keys()))
         }
 
 

--- a/scraper/export/resource_centres.py
+++ b/scraper/export/resource_centres.py
@@ -62,15 +62,19 @@ class ResourceTousDepartements(Resource):
         return {
             "version": 1,
             "last_updated": self.now(tz=gettz()).replace(microsecond=0).isoformat(),
-            "centres_disponibles": sorted([self.centre_asdict(c) for c in self.centres_disponibles.values()], key=sort_center),
-            "centres_indisponibles": [self.centre_asdict(c) for c in self.centres_indisponibles.values()]
+            "centres_disponibles": sorted(
+                [self.centre_asdict(c) for c in self.centres_disponibles.values()], key=sort_center
+            ),
+            "centres_indisponibles": [self.centre_asdict(c) for c in self.centres_indisponibles.values()],
         }
 
     def centre_asdict(self, centre):
         return {
             **centre,
-            'prochain_rdv': centre['prochain_rdv'].replace(microsecond=0).isoformat() if centre['prochain_rdv'] else None,
-            'vaccine_type': sorted(list(centre['vaccine_type'].keys()))
+            "prochain_rdv": centre["prochain_rdv"].replace(microsecond=0).isoformat()
+            if centre["prochain_rdv"]
+            else None,
+            "vaccine_type": sorted(list(centre["vaccine_type"].keys())),
         }
 
 

--- a/scraper/export/resource_creneaux_quotidiens.py
+++ b/scraper/export/resource_creneaux_quotidiens.py
@@ -23,7 +23,7 @@ class ResourceCreneauxQuotidiens(Resource):
             self.dates[date] = ResourceCreneauxParDate(date=date, tags=tags)
 
     def on_creneau(self, creneau: Union[Creneau, PasDeCreneau]):
-        if creneau.lieu.departement == self.departement and creneau.disponible:
+        if creneau.disponible and creneau.lieu.departement == self.departement:
             date = as_date(creneau.horaire)
             if date in self.dates:
                 self.dates[date].on_creneau(creneau)
@@ -78,4 +78,4 @@ class ResourceCreneauxParLieu(Resource):
 
 
 def as_date(datetime):
-    return datetime.strftime("%Y-%m-%d")
+    return datetime.isoformat()[:10]

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -66,7 +66,11 @@ def scrape(platforms=None):  # pragma: no cover
             creneau_q = BulkQueue(manager.Queue(maxsize=99999))
             export_process = Process(target=export_by_creneau, args=(creneau_q,))
             export_process.start()
-            centre_iterator_proportion = ((c, DummyQueue() if CRENEAUX_DISABLED else creneau_q) for c in centre_iterator(platforms=platforms) if random() < PARTIAL_SCRAPE)
+            centre_iterator_proportion = (
+                (c, DummyQueue() if CRENEAUX_DISABLED else creneau_q)
+                for c in centre_iterator(platforms=platforms)
+                if random() < PARTIAL_SCRAPE
+            )
             centres_cherchés = pool.imap_unordered(cherche_prochain_rdv_dans_centre, centre_iterator_proportion, 1)
 
             centres_cherchés = get_last_scans(centres_cherchés)

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -15,7 +15,7 @@ from scraper.pattern.scraper_result import ScraperResult, VACCINATION_CENTER
 from scraper.profiler import Profiling
 from utils.vmd_config import get_conf_platform
 from utils.vmd_logger import enable_logger_for_production, enable_logger_for_debug, log_requests, log_platform_requests
-from utils.vmd_utils import fix_scrap_urls, get_last_scans, get_start_date, q_iter, EOQ, DummyQueue
+from utils.vmd_utils import fix_scrap_urls, get_last_scans, get_start_date, q_iter, EOQ, DummyQueue, BulkQueue
 from .doctolib.doctolib import center_iterator as doctolib_center_iterator
 from .doctolib.doctolib import fetch_slots as doctolib_fetch_slots
 from .export.export_merge import export_data
@@ -61,15 +61,16 @@ def scrape(platforms=None):  # pragma: no cover
     compte_centres_avec_dispo = 0
     compte_bloqués = 0
     profiler = Profiling()
-    with profiler, Manager() as manager, Pool(POOL_SIZE, **profiler.pool_args()) as pool:
-        creneau_q = manager.Queue(maxsize=999999)
-        export_process = Process(target=export_by_creneau, args=(creneau_q,))
-        export_process.start()
-        centre_iterator_proportion = ((c, DummyQueue() if CRENEAUX_DISABLED else creneau_q) for c in centre_iterator(platforms=platforms) if random() < PARTIAL_SCRAPE)
-        centres_cherchés = pool.imap_unordered(cherche_prochain_rdv_dans_centre, centre_iterator_proportion, 1)
+    with Manager() as manager:
+        with profiler, Pool(POOL_SIZE, **profiler.pool_args()) as pool:
+            creneau_q = BulkQueue(manager.Queue(maxsize=99999))
+            export_process = Process(target=export_by_creneau, args=(creneau_q,))
+            export_process.start()
+            centre_iterator_proportion = ((c, DummyQueue() if CRENEAUX_DISABLED else creneau_q) for c in centre_iterator(platforms=platforms) if random() < PARTIAL_SCRAPE)
+            centres_cherchés = pool.imap_unordered(cherche_prochain_rdv_dans_centre, centre_iterator_proportion, 1)
 
-        centres_cherchés = get_last_scans(centres_cherchés)
-        log_platform_requests(centres_cherchés)
+            centres_cherchés = get_last_scans(centres_cherchés)
+            log_platform_requests(centres_cherchés)
 
         creneau_q.put(EOQ)
         export_process.join()

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -275,7 +275,7 @@ def q_iter(q, EOQ=EOQ):
 
 
 class BulkQueue:
-    def __init__(self, q, bulksize=500, delay=0.200):
+    def __init__(self, q, bulksize=300, delay=5):
         self.q = q
         self.bulksize = bulksize
         self.current_read = None

--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -1,5 +1,6 @@
 import re
 import csv
+import threading
 import json
 import logging
 from typing import List, Optional
@@ -271,3 +272,46 @@ EOQ = "EOQ-f43732d8-c250-11eb-8d1f-f38a886756c1"
 
 def q_iter(q, EOQ=EOQ):
     return iter(q.get, EOQ)
+
+
+class BulkQueue:
+    def __init__(self, q, bulksize=500, delay=0.200):
+        self.q = q
+        self.bulksize = bulksize
+        self.current_read = None
+        self.current_bulk = []
+        self._scheduled_timer = None
+        self.delay = delay
+
+    def put(self, item):
+        self.current_bulk.append(item)
+        if len(self.current_bulk) >= self.bulksize:
+            self._flush()
+            return None
+
+        if self._scheduled_timer:
+            self._scheduled_timer.cancel()
+
+        self._scheduled_timer = threading.Timer(self.delay, self._flush)
+        self._scheduled_timer.start()
+
+    def get(self):
+        if not self.current_read:
+            next_bulk = self.q.get()
+            self.current_read = iter(next_bulk)
+
+        try:
+            return next(self.current_read)
+        except StopIteration:
+            self.current_read = None
+            return self.get()
+
+    def delayed_flush(self):
+        self._flush()
+
+    def _flush(self):
+        if not self.current_bulk or len(self.current_bulk) == 0:
+            return
+        bulk = self.current_bulk
+        self.current_bulk = []
+        self.q.put(bulk)


### PR DESCRIPTION
**Checklist**

- [ ] Fix #issue
- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Permet de limiter la quantité de CPU utilisé lors de l'export des données afin que la rapidité de la consommation ne soit pas un facteur limitant pour écrire dans la file.
D'autre part, les éléments de la file sont envoyé en lot (bulk) pour limiter l'utilisation d'I/O, c'est possible car l'ordre n'est pas important.


Voici le flamegraph de du processus de l'export après optimisations
![image](https://user-images.githubusercontent.com/235570/120691317-964a5080-c4a6-11eb-9c7e-d05544126456.png)

A comparer à avant :
![image](https://user-images.githubusercontent.com/235570/120691434-be39b400-c4a6-11eb-9f42-673e0a408e9e.png)

On voit que plus de temps est passé à effectivement traiter la donnée plutôt qu'à l'attendre.


On gagne un peu plus d'une minute de temps d'execution 
Avec : https://gitlab.com/ViteMaDose/vitemadose-staging/-/jobs/1316400295
Sans : https://gitlab.com/ViteMaDose/vitemadose-staging/-/jobs/1309954501