### PR TITLE
[Doctolib] - Gestion des doublons

### DIFF
--- a/scraper/error.py
+++ b/scraper/error.py
@@ -9,3 +9,8 @@ class BlockedByDoctolibError(ScrapeError):
     def __init__(self, url):
         super().__init__("Doctolib", f"Doctolib bloque nos appels: 403 {url}")
         self.blocked = True
+
+
+class DoublonDoctolib(ScrapeError):
+    def __init__(self, url):
+        super().__init__("Doctolib", f"Le centre est un doublon {url}")

--- a/tests/fixtures/doctolib/basic-booking.json
+++ b/tests/fixtures/doctolib/basic-booking.json
@@ -16,7 +16,9 @@
       {
         "id": 3,
         "visit_motive_ids_by_practice_id": {
-          "4": [2]
+          "165752": [
+            2
+          ]
         },
         "booking_disabled": false
       }

--- a/tests/fixtures/doctolib/category-booking.json
+++ b/tests/fixtures/doctolib/category-booking.json
@@ -19,7 +19,9 @@
       {
         "id": 3,
         "visit_motive_ids_by_practice_id": {
-          "4": [2]
+          "165752": [
+            2
+          ]
         },
         "booking_disabled": false
       }

--- a/tests/fixtures/doctolib/next-slot-booking.json
+++ b/tests/fixtures/doctolib/next-slot-booking.json
@@ -19,7 +19,9 @@
       {
         "id": 3,
         "visit_motive_ids_by_practice_id": {
-          "4": [2]
+          "165752": [
+            2
+          ]
         },
         "booking_disabled": false
       }

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -473,26 +473,28 @@ def test_find_agenda_and_practice_ids():
         ],
     }
 
-    agenda_ids, practice_ids, is_doublon = _find_agenda_and_practice_ids(data, visit_motive_ids={1}, practice_id_url=20)
+    agenda_ids, practice_ids, is_doublon = _find_agenda_and_practice_ids(
+        data, visit_motive_ids={1}, practice_id_from_url=20
+    )
 
     assert agenda_ids == ["10", "12"]
     assert practice_ids == ["20", "21", "24"]
-    assert is_doublon == False
+    assert not is_doublon
 
     agenda_ids, practice_ids, is_doublon = _find_agenda_and_practice_ids(
-        data, visit_motive_ids={1}, practice_id_url=21, practice_id_filter=[21]
+        data, visit_motive_ids={1}, practice_id_from_url=21, practice_id_filter=[21]
     )
     assert agenda_ids == ["12"]
     assert practice_ids == ["21", "24"]
-    assert is_doublon == False
+    assert not is_doublon
 
     agenda_ids, practice_ids, is_doublon = _find_agenda_and_practice_ids(
-        data, visit_motive_ids={1}, practice_id_url=35, practice_id_filter=[21]
+        data, visit_motive_ids={1}, practice_id_from_url=35, practice_id_filter=[21]
     )
 
     assert agenda_ids == ["12"]
     assert practice_ids == ["21", "24"]
-    assert is_doublon == True
+    assert is_doublon
 
 
 def test_category_relevant():

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -472,13 +472,24 @@ def test_find_agenda_and_practice_ids():
             },
         ],
     }
-    agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=1)
+    agenda_ids, practice_ids, is_doublon = _find_agenda_and_practice_ids(data, visit_motive_id=1, practice_id_url=20)
     assert agenda_ids == ["10", "12"]
     assert practice_ids == ["20", "21", "24"]
+    assert is_doublon == False
 
-    agenda_ids, practice_ids = _find_agenda_and_practice_ids(data, visit_motive_id=1, practice_id_filter=[21])
+    agenda_ids, practice_ids, is_doublon = _find_agenda_and_practice_ids(
+        data, visit_motive_id=1, practice_id_url=21, practice_id_filter=[21]
+    )
     assert agenda_ids == ["12"]
     assert practice_ids == ["21", "24"]
+    assert is_doublon == False
+
+    agenda_ids, practice_ids, is_doublon = _find_agenda_and_practice_ids(
+        data, visit_motive_id=1, practice_id_url=35, practice_id_filter=[21]
+    )
+    assert agenda_ids == ["12"]
+    assert practice_ids == ["21", "24"]
+    assert is_doublon == True
 
 
 def test_category_relevant():

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -355,12 +355,13 @@ def test_export_data_when_blocked(tmp_path):
 
     fake_now = dt.datetime(2021, 4, 4)
     with mock_datetime_now(fake_now):
-        total, actifs, bloqués = export_data(centres_cherchés, [], outpath_format=outpath_format)
+        total, actifs, bloqués, doublons = export_data(centres_cherchés, [], outpath_format=outpath_format)
 
     # les totaux doivent être bons
     assert total == 2
     assert actifs == 1
     assert bloqués == 1
+    assert doublons == 0
 
     # Departements 14 and 59 should contain expected data.
     content = json.loads((out_dir / "14.json").read_text())


### PR DESCRIPTION
**Checklist**

- [424, 490, 495 ] Fix #issue
- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Gestion des doublons pour Doctolib.
En gros, dans la page booking/centre.json, il faut vérifier que dans l'agenda en cours, le pid du centre est bien dans les keys de visit_motive_ids_by_practice_id 

Par exemple, admettons que notre pid soit 125410, si l'agenda en cours de la page booking contient `"visit_motive_ids_by_practice_id":{"164604":[2548342,2548343]}`, c'est que le centre 125410 est un ancien centre qu'il ne faut pas mettre dans les json.

Ce centre finit par disparaitre de la page vaccination-covid-19/departement.json mais cela met plusieurs jours voir semaines, d'où ma solution pour éviter les centres en quadruple (en sachant qu'il y a pas mal de centres temporaires qui ne sont là que pour quelques jours !)

@Floby @Maijin @Noezor @gaelbenoit puis je demander à l'un de vous une review rapide ? Car j'ai peur que ces modifs fassent conflit avec des PR en cours, notamment la liste manuelle des centres de @ValentinMouret, donc ca serait bien de merge rapidement !

