### PR TITLE
[Doctolib Center Scrap] - Add traceback for debug

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -77,7 +77,8 @@ class DoctolibCenterScraper:
             )
             data = r.json()
         except:
-            logger.warn(f"> Could not retrieve centers from department {departement} page_id {page_id}.")
+
+            logger.warn(f"> Could not retrieve centers from department {departement} page_id {page_id}  => {r}.")
             return [], False
 
         return self.centers_from_page(data, liste_urls)


### PR DESCRIPTION
Le Doctolib Center Scrap pose soucis depuis quelques heures, j'ai rajouté le statuscode de la requete dans le logger pour pouvoir débug.