### PR TITLE
Correction du logo Bimedoc sur le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ La plupart des IDEs et éditeurs de code moderne proposent des outils permettant
 | <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_mapharma.png" width="100" /> | https://www.mapharma.net/ | <font style="color: green; font-size: 16px;">✓</font> |
 | <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_avecmondoc.png" width="100" /> | https://www.avecmondoc.com/ | <font style="color: green; font-size: 16px;">✓</font> |
 | <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_mesoigner.png" width="100" /> | https://www.mesoigner.fr/ | <font style="color: green; font-size: 16px;">✓</font> |
-| <img src="https://vitemadose.covidtracker.fr/assets/images/png/logo_bimedoc.png" width="100" /> | https://www.bimedoc.com/ | <font style="color: green; font-size: 16px;">✓</font> |
+| <img src="https://vitemadose.covidtracker.fr/assets/images/logo/logo_bimedoc.svg" width="100" /> | https://www.bimedoc.com/ | <font style="color: green; font-size: 16px;">✓</font> |
 
 ## Utilisation
 


### PR DESCRIPTION
**Checklist**

- [x] ~~Fix #issue~~ (non applicable)
- [x] ~~J'ai ajouté des tests (si nécessaire)~~ (non applicable)
- [x] ~~J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`~~ (non applicable)

**Description**

L’URL du logo de Bimedoc dans le README n’est actuellement pas correcte, elle cause une erreur 404. Cette PR corrige cela.