### PR TITLE
[Doctolib] - Increasing Days Per Page

### DIFF
--- a/config.json
+++ b/config.json
@@ -90,7 +90,7 @@
                 "scraper_dep": "http://www.doctolib.fr/vaccination-covid-19/{0}.json?page={1}"
             },
             "request_sleep": 0.05,
-            "days_per_page": 7,
+            "days_per_page": 14,
             "filters": {
                 "appointment_reason": [
                     "1 ere injection",

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -151,7 +151,7 @@ def test_doctolib_sends_creneau():
     while not q.empty():
         actual.append(q.get())
     # Then
-    assert len(actual) == 2
+    assert len(actual) == 1
     assert actual[0] == Creneau(
         reservation_url=base_url,
         horaire=dateutil.parser.parse("2021-04-10"),


### PR DESCRIPTION

- [x] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

Currently, we are targetting API by 7 days requests.
It is now possible to target by 14 days range, and it's exactly what I did !
We won 2k requests on each scrape with the same results.