### PR TITLE
[doctolib] - Retrait 2e doses

### DIFF
--- a/config.json
+++ b/config.json
@@ -126,18 +126,6 @@
                         "dose": 1,
                         "vaccine": "Janssen"
                     },
-                    "7108": {
-                        "dose": 2,
-                        "vaccine": "AstraZeneca"
-                    },
-                    "7004": {
-                        "dose": 2,
-                        "vaccine": "Moderna"
-                    },
-                    "6971": {
-                        "dose": 2,
-                        "vaccine": "Pfizer-BioNTech"
-                    },
                     "8192": {
                         "dose": 3,
                         "vaccine": "Pfizer-BioNTech"

--- a/tests/test_doctolib.py
+++ b/tests/test_doctolib.py
@@ -448,9 +448,9 @@ def test_find_visit_motive_id():
         ]
     }
     assert _find_visit_motive_id(data, visit_motive_category_id=[42]) == {
-        Vaccine.MODERNA: {(1, 1), (4, 2)},
-        Vaccine.ASTRAZENECA: {(2, 1), (5, 2)},
-        Vaccine.PFIZER: {(3, 1), (6, 2)},
+        Vaccine.MODERNA: {(1, 1)},
+        Vaccine.ASTRAZENECA: {(2, 1)},
+        Vaccine.PFIZER: {(3, 1)},
     }
 
 


### PR DESCRIPTION
Au vu du fonctionnement de doctolib (reservation de la 2e dose lors de la prise de rdv pour la 1ère), il n'est pas nécessaire de scraper les 2e doses. Cette amélioration vise à l'accélération du temps de scrape.