### PR TITLE
Prise en compte du rang d'injection pour AvecMonDoc

### DIFF
--- a/config.json
+++ b/config.json
@@ -677,8 +677,8 @@
                     "Rendez-vous de première vaccination Covid",
                     "Deuxieme injection vaccinale COVID",
                     "Deuxième injection vaccinale COVID",
-                    "Troisieme injection vaccinale COVID"
-                    "Troisième injection vaccinale COVID"
+                    "Troisieme injection vaccinale COVID",
+                    "Troisième injection vaccinale COVID",
                     "1ere vaccination astra",
                     "Injection vaccinale COVID-19 - Janssen",
                     "Injection monodose Janssen",

--- a/config.json
+++ b/config.json
@@ -670,20 +670,12 @@
             },
             "filters": {
                 "valid_reasons": [
-                    "Premiere injection COVID",
-                    "Première injection COVID",
-                    "Permière injection COVID",
-                    "Première injection vaccinale COVID",
-                    "Rendez-vous de première vaccination Covid",
-                    "Deuxieme injection vaccinale COVID",
-                    "Deuxième injection vaccinale COVID",
-                    "Troisieme injection vaccinale COVID",
-                    "Troisième injection vaccinale COVID",
+                    "injection COVID",
+                    "injection vaccinale COVID",
+                    "vaccination Covid",
                     "1ere vaccination astra",
-                    "Injection vaccinale COVID-19 - Janssen",
                     "Injection monodose Janssen",
-                    "Injection vaccinale monodose Janssen",
-                    "Vaccination covid 19 janssen"
+                    "Injection vaccinale monodose Janssen"
                 ]
             },
             "center_scraper": {

--- a/config.json
+++ b/config.json
@@ -675,6 +675,10 @@
                     "Permière injection COVID",
                     "Première injection vaccinale COVID",
                     "Rendez-vous de première vaccination Covid",
+                    "Deuxieme injection vaccinale COVID",
+                    "Deuxième injection vaccinale COVID",
+                    "Troisieme injection vaccinale COVID"
+                    "Troisième injection vaccinale COVID"
                     "1ere vaccination astra",
                     "Injection vaccinale COVID-19 - Janssen",
                     "Injection monodose Janssen",

--- a/scraper/avecmondoc/avecmondoc.py
+++ b/scraper/avecmondoc/avecmondoc.py
@@ -341,7 +341,7 @@ class AvecmonDoc:
             return None
         return first_availability.isoformat()
 
-def get_vaccine_dose(motive_name):
+def get_vaccine_dose(motive_name: str) -> Optional[list]:
     if not motive_name:
         return None
     dose = []

--- a/scraper/avecmondoc/avecmondoc.py
+++ b/scraper/avecmondoc/avecmondoc.py
@@ -264,7 +264,7 @@ class AvecmonDoc:
         self.creneau_q.put(creneau)
 
     def parse_availabilities(
-        self, availabilities: list, request: ScraperRequest, vaccine: Vaccine, dose: list = None
+        self, availabilities: list, request: ScraperRequest, vaccine: Vaccine, dose: Optional[list] = None
     ) -> Tuple[Optional[datetime], int]:
         first_appointment = None
         appointment_count = 0

--- a/scraper/avecmondoc/avecmondoc.py
+++ b/scraper/avecmondoc/avecmondoc.py
@@ -346,20 +346,24 @@ def get_vaccine_dose(motive_name: str) -> Optional[list]:
         return None
     dose = []
     motive_low = motive_name.lower()
-    if "première" in motive_low or "premiere" in motive_low:
+    if (
+        "première" in motive_low 
+        or "premiere" in motive_low
+        or "1è" in motive_low
+    ):
         dose.append(1)
     if (
         "deuxième" in motive_low
         or "deuxieme" in motive_low
         or "seconde" in motive_low
-        or "2" in motive_low
+        or "2è" in motive_low
     ):
         dose.append(2)
     if (
         "rappel" in motive_low
         or "troisième" in motive_low
         or "troisieme" in motive_low
-        or "3" in motive_low
+        or "3è" in motive_low
     ):
         dose.append(3)
     return dose

--- a/tests/test_avecmondoc.py
+++ b/tests/test_avecmondoc.py
@@ -128,6 +128,10 @@ def test_get_valid_reasons():
         {
             "reason": "Première injection vaccinale COVID-19",
             "id": 604,
+        },
+        {
+            "reason": "Seconde injection vaccinale COVID-19",
+            "id": 605,
         }
     ]
 
@@ -232,7 +236,7 @@ def test_fetch_slots():
     request = ScraperRequest(url, "2021-05-20", center_info=center_info)
     first_availability = fetch_slots(request, client=client)
     assert first_availability == "2021-05-20T09:00:00+00:00"
-    assert request.vaccine_type == ["Pfizer-BioNTech"]
+    assert request.vaccine_type == ["Pfizer-BioNTech", "Janssen"]
 
 
 def test_center_to_centerdict():


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [x] Fix #678 

**Description**

Le rang d'injection n'est pas détecté par le scraper AvecMonDoc. Du coup le front-end qui filtre part rang d'injection connu n'affiche plus les créneaux disponibles car ils ne sont pas associés à un rang d'injection. J'ai donc ajouté la détection du rang en fonction du motif (Première injection, Deuxième injection, Troisième injection), tout en ajoutant les deuxièmes et troisièmes injection comme motifs valides dans le fichier config.json
