### PR TITLE
Extraire correctement le practice_id de "places" avec Doctolib

### DIFF
--- a/scraper/doctolib/doctolib.py
+++ b/scraper/doctolib/doctolib.py
@@ -144,7 +144,7 @@ class DoctolibSlots:
 
         if practice_id:
             practice_id, practice_same_adress = link_practice_ids(practice_id, rdata)
-        if len(rdata.get("places", [])) > 1 and practice_id is None:
+        if len(rdata.get("places", [])) >= 1 and practice_id is None:
             practice_id = rdata.get("places")[0].get("practice_ids", None)
 
         if len(rdata.get("places", [])) == 0 and practice_id is None:


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [x] Fix #680
- [x] Fix #676 
- [ ] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Sur Doctolib, le `practice_id`soit depuis l'URL soit depuis le champ `places` de l'API booking. Dans le second cas, le cas actuel ne gérait pas le cas où `places` ne contenait qu'un seul élément, `practice_id` restait à None et le scrape crashait plus loin quand on essaye d'itérer sur `None` (c'est un autre bug à corriger ça), résultat le centre n'apparaît pas dans la sortie du scrape. Il y a au moins deux centres concernés (cf les issues) mais je pense qu'il y a en a bien plus en pratique.

<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
