### PR TITLE
Retourner un exit code d'erreur en cas d'échec du scrap de centres

### DIFF
--- a/scraper/doctolib/doctolib_center_scrap.py
+++ b/scraper/doctolib/doctolib_center_scrap.py
@@ -173,6 +173,7 @@ if __name__ == "__main__":  # pragma: no cover
         if len(centers) < 2000:
             # for reference, on 13-05, there were 12k centers
             logger.error(f"[NOT SAVING RESULTS]{len(centers)} does not seem like enough Doctolib centers")
+            exit(1)
         else:
             logger.info(f"> Writing them on {path_out}")
             with open(path_out, "w") as f:

--- a/scraper/keldoc/keldoc_center_scrap.py
+++ b/scraper/keldoc/keldoc_center_scrap.py
@@ -307,6 +307,7 @@ if __name__ == "__main__":  # pragma: no cover
         if len(centers) < 90:
             # for reference, on 17-05, there were 97 centers
             logger.error(f"[NOT SAVING RESULTS] {len(centers)} does not seem like enough Keldoc centers")
+            exit(1)
         else:
             logger.info(f"> Writing them on {path_out}")
             with open(path_out, "w") as f:

--- a/scraper/mesoigner/mesoigner_center_scrap.py
+++ b/scraper/mesoigner/mesoigner_center_scrap.py
@@ -123,6 +123,7 @@ if __name__ == "__main__":  # pragma: no cover
         logger.info(f"Found {len(centers)} centers on Mesoigner")
         if len(centers) < SCRAPER_CONF.get("minimum_results", 0):
             logger.error(f"[NOT SAVING RESULTS]{len(centers)} does not seem like enough Mesoigner centers")
+            exit(1)
         else:
             logger.info(f"> Writing them on {path_out}")
             with open(path_out, "w") as f:


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [ ] Fix #issue
- [ ] J'ai ajouté des tests (si nécessaire)
- [x] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Actuellement les scraps de centres de certaines plateformes retourne un code d'erreur 0 en cas d'un nombre insuffisant de centres (voire même pas de centre du tout), par conséquent, la CI pense que la tâche a fini avec succès (cf ce job https://github.com/CovidTrackerFr/vitemadose/runs/4914359773?check_suite_focus=true). Avec un exit code à 1, le job remontera correctement un échec.

<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
