### PR TITLE
Eviter une KeyError en cas d'erreur HTTP dans get_last_scans()

### DIFF
--- a/utils/vmd_utils.py
+++ b/utils/vmd_utils.py
@@ -249,7 +249,7 @@ def get_last_scans(centres):
 
     except Exception as e:
         logger.warning(f"Impossible de récupérer le fichier info_centres: {e}")
-        info_centres = {}
+        info_centres = {"centres_disponibles": [], "centres_indisponibles": []}
 
     for centre in info_centres["centres_disponibles"] + info_centres["centres_indisponibles"]:
         if "last_scan_with_availabilities" in centre:


### PR DESCRIPTION
<!-- 
En bref :
* Le titre du PR doit commencer par une majuscule et être concis.
* Suivre le style de codage, ajouter des tests
-->

**Checklist**

- [ ] Fix #issue
- [ ] J'ai ajouté des tests (si nécessaire)
- [ ] J'ai formatté/identé mon code en utilisant [black](https://github.com/psf/black) - `black -l 120 fileXX fileYY`

**Description**

Le job `trouver_les_rdv` fail à l'export (https://gitlab.com/ViteMaDose/vitemadose/-/jobs/2008834498) si `info_centres.json` ne peut pas être récupéré (erreur 404). Ce changement permet de gérer gracieusement l'absence des données de `info_centres.json`. Je n'ai pas testé, j'espère juste que ça fonctionne :crossed_fingers: 

<!-- Expliquez les **détails** pour comprendre le but de cette contribution, avec suffisamment d'informations pour nous aider à mieux comprendre les changements. -->
